### PR TITLE
fix: show goal of empty nested `by` block at positions indented past the enclosing tactic

### DIFF
--- a/src/Lean/Server/InfoUtils.lean
+++ b/src/Lean/Server/InfoUtils.lean
@@ -408,6 +408,12 @@ structure GoalsAtResult where
   useAfter   : Bool
   /-- Whether the tactic info is further indented than the hover position. -/
   indented   : Bool
+  /--
+  Whether the tactic info is a `by` block or its `by` token. Whether such a node counts as
+  `indented` is decided by the enclosing tactic, if any, since the column of the `by` token says
+  nothing about where the block's tactics are placed.
+  -/
+  hangingBy  : Bool := false
   -- for overlapping goals, only keep those of the highest reported priority
   priority   : Nat
 
@@ -422,17 +428,30 @@ structure GoalsAtResult where
   |
   ```
   we show the (final, see below) state of `have`, not `exact`.
+  A `by` block whose tactics are all indented relative to the hover position (in particular an
+  empty one) is itself considered indented iff the hover position is not indented past the
+  enclosing tactic, i.e. iff a tactic typed there would extend the outer block instead:
+  ```lean
+  have := by
+    |  -- goal of `have`
+  |    -- state after `have`
+  ```
 
   Moreover, we instruct the LSP server to use the state after tactic execution if
   - the hover position is after the info's start position *and*
   - there is no nested tactic info after the hover position (tactic combinators should decide for themselves
     where to show intermediate states by calling `withTacticInfoContext`) -/
 partial def InfoTree.goalsAt? (text : FileMap) (t : InfoTree) (hoverPos : String.Pos.Raw) : List GoalsAtResult :=
+  let hoverCol := (text.toPosition hoverPos).column
   let gs := t.collectNodesBottomUp fun ctx i cs gs => Id.run do
     let Info.ofTacticInfo ti := i
       | return gs
     let (some pos, some tailPos) := (i.pos?, i.tailPos?)
       | return gs
+    let col := (text.toPosition pos).column
+    -- decide indentation of hanging `by` results relative to this enclosing tactic
+    let gs := gs.map fun g =>
+      if g.hangingBy then { g with hangingBy := false, indented := hoverCol ≤ col } else g
     let trailSize := i.stx.getTrailingSize
     -- show info at EOF even if strictly outside token + trail
     let atEOF := tailPos.byteIdx + trailSize == text.source.rawEndPos.byteIdx
@@ -444,7 +463,8 @@ partial def InfoTree.goalsAt? (text : FileMap) (t : InfoTree) (hoverPos : String
           ctxInfo := ctx
           tacticInfo := ti
           useAfter := hoverPos > pos && !cs.any (hasNestedTactic pos tailPos)
-          indented := (text.toPosition pos).column > (text.toPosition hoverPos).column
+          indented := col > hoverCol
+          hangingBy := isByBlock i.stx
           -- use goals just before cursor as fall-back only
           -- thus for `(by foo)`, placing the cursor after `foo` shows its state as long
           -- as there is no state on `)`
@@ -467,6 +487,9 @@ where
     | InfoTree.node (Info.ofMacroExpansionInfo _) cs =>
       cs.any (hasNestedTactic pos tailPos)
     | _ => false
+  isByBlock (stx : Syntax) : Bool :=
+    -- there are multiple `by` kinds with the same structure
+    stx.isToken "by" || stx.getNumArgs == 2 && stx[0].isToken "by"
 
 
 partial def InfoTree.termGoalAt? (t : InfoTree) (hoverPos : String.Pos.Raw) : Option InfoWithCtx :=

--- a/tests/server_interactive/plainGoal.lean.out.expected
+++ b/tests/server_interactive/plainGoal.lean.out.expected
@@ -145,16 +145,14 @@ null
 {"rendered": "no goals", "goals": []}
 {"textDocument": {"uri": "file:///plainGoal.lean"},
  "position": {"line": 107, "character": 4}}
-{"rendered": "```lean\nthis : True\n⊢ True\n```",
- "goals": ["this : True\n⊢ True"]}
+{"rendered": "```lean\n⊢ True\n```", "goals": ["⊢ True"]}
 {"textDocument": {"uri": "file:///plainGoal.lean"},
  "position": {"line": 109, "character": 2}}
 {"rendered": "```lean\nthis : True\n⊢ True\n```",
  "goals": ["this : True\n⊢ True"]}
 {"textDocument": {"uri": "file:///plainGoal.lean"},
  "position": {"line": 114, "character": 4}}
-{"rendered": "```lean\nthis : True\n⊢ True\n```",
- "goals": ["this : True\n⊢ True"]}
+{"rendered": "```lean\n⊢ True\n```", "goals": ["⊢ True"]}
 {"textDocument": {"uri": "file:///plainGoal.lean"},
  "position": {"line": 116, "character": 2}}
 {"rendered": "```lean\nthis : True\n⊢ True\n```",

--- a/tests/server_interactive/plainGoalEmptyByNested.lean
+++ b/tests/server_interactive/plainGoalEmptyByNested.lean
@@ -1,0 +1,34 @@
+/-!
+Regression tests for #15053 (and #1927): after an empty nested `have ... := by`, positions that
+are indented past the `have` must show the goal of the empty block, not the state after `have`.
+The `by` block's own column must not count as indentation.
+-/
+
+-- Issue example 2: expected `⊢ True` right after `by` (col 19) and on the next line at cols 5 and
+-- 3; the outer state is shown at col 0 (and at col 2, the `have` column).
+example : False := by
+  have : True := by
+                 --^ $/lean/plainGoal
+    -- cursor here
+   --^ $/lean/plainGoal
+ --^ $/lean/plainGoal
+--⬑ $/lean/plainGoal
+
+-- Same, but with a completely empty line and a following outer tactic
+example : False := by
+  have : True := by
+
+  --^ $/lean/plainGoal
+  sorry
+
+example : False := by
+  have : True := by
+    -- cursor here
+   --^ $/lean/plainGoal
+ --^ $/lean/plainGoal
+  sorry
+
+-- Control: empty top-level `by` at EOF (`plainGoalEmptyBy.lean` covers more of these)
+example : False := by
+  -- cursor here
+ --^ $/lean/plainGoal

--- a/tests/server_interactive/plainGoalEmptyByNested.lean.out.expected
+++ b/tests/server_interactive/plainGoalEmptyByNested.lean.out.expected
@@ -1,0 +1,25 @@
+{"textDocument": {"uri": "file:///plainGoalEmptyByNested.lean"},
+ "position": {"line": 9, "character": 19}}
+{"rendered": "```lean\n⊢ True\n```", "goals": ["⊢ True"]}
+{"textDocument": {"uri": "file:///plainGoalEmptyByNested.lean"},
+ "position": {"line": 11, "character": 5}}
+{"rendered": "```lean\n⊢ True\n```", "goals": ["⊢ True"]}
+{"textDocument": {"uri": "file:///plainGoalEmptyByNested.lean"},
+ "position": {"line": 11, "character": 3}}
+{"rendered": "```lean\n⊢ True\n```", "goals": ["⊢ True"]}
+{"textDocument": {"uri": "file:///plainGoalEmptyByNested.lean"},
+ "position": {"line": 11, "character": 0}}
+{"rendered": "```lean\nthis : True\n⊢ False\n```",
+ "goals": ["this : True\n⊢ False"]}
+{"textDocument": {"uri": "file:///plainGoalEmptyByNested.lean"},
+ "position": {"line": 19, "character": 4}}
+{"rendered": "```lean\n⊢ True\n```", "goals": ["⊢ True"]}
+{"textDocument": {"uri": "file:///plainGoalEmptyByNested.lean"},
+ "position": {"line": 25, "character": 5}}
+{"rendered": "```lean\n⊢ True\n```", "goals": ["⊢ True"]}
+{"textDocument": {"uri": "file:///plainGoalEmptyByNested.lean"},
+ "position": {"line": 25, "character": 3}}
+{"rendered": "```lean\n⊢ True\n```", "goals": ["⊢ True"]}
+{"textDocument": {"uri": "file:///plainGoalEmptyByNested.lean"},
+ "position": {"line": 32, "character": 3}}
+{"rendered": "```lean\n⊢ False\n```", "goals": ["⊢ False"]}


### PR DESCRIPTION
This PR fixes the goal view showing the state after `have` instead of the goal of an empty nested `have ... := by` block on the following line, where the next tactic is about to be typed (#15053, regression of #1927 from #13229).

The `isEmptyBy` heuristic in `InfoTree.goalsAt?` was removed in #13229 because empty `by` blocks no longer produce `.missing` syntax. Instead of checking for emptiness, `by` blocks and tokens are now flagged as `hangingBy`, and whether they count as indented is decided by the enclosing tactic by comparing the hover column with its own column, which matches where the parser would put a tactic typed at that position.