### PR TITLE
feat: bundle the `nanoda` external checker with release toolchains

### DIFF
--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -266,7 +266,8 @@ jobs:
           elan --version  # fails step if not found
           make -C build/$TARGET_STAGE lean4lean
       - name: Build nanoda
-        if: matrix.release && !matrix.wasm && inputs.RELEASE_TAG != '' && github.repository == 'leanprover/lean4'
+        # TEMPORARY: gating removed so PR CI exercises this. Restore before merging.
+        if: "!matrix.wasm"
         run: |
           # install inline instead of via an action, which would choose a different HOME on Windows
           if ! command -v cargo > /dev/null; then

--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -266,8 +266,7 @@ jobs:
           elan --version  # fails step if not found
           make -C build/$TARGET_STAGE lean4lean
       - name: Build nanoda
-        # TEMPORARY: gating removed so PR CI exercises this. Restore before merging.
-        if: "!matrix.wasm"
+        if: matrix.release && !matrix.wasm && inputs.RELEASE_TAG != '' && github.repository == 'leanprover/lean4'
         run: |
           # msys2 trims the Windows `PATH`, hiding the runner's cargo, and a native rustup installs
           # to `%USERPROFILE%` rather than to the msys2 `$HOME`

--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -266,7 +266,7 @@ jobs:
           elan --version  # fails step if not found
           make -C build/$TARGET_STAGE lean4lean
       - name: Build nanoda
-        if: matrix.release && !matrix.wasm && inputs.RELEASE_TAG != '' && github.repository == 'leanprover/lean4'
+        if: matrix.release && !matrix.wasm
         run: |
           # msys2 hides the runner's preinstalled cargo by trimming the Windows `PATH`
           if command -v cygpath > /dev/null && [ -n "${USERPROFILE:-}" ]; then

--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -269,6 +269,11 @@ jobs:
         # TEMPORARY: gating removed so PR CI exercises this. Restore before merging.
         if: "!matrix.wasm"
         run: |
+          # msys2 trims the Windows `PATH`, hiding the runner's cargo, and a native rustup installs
+          # to `%USERPROFILE%` rather than to the msys2 `$HOME`
+          if command -v cygpath > /dev/null && [ -n "${USERPROFILE:-}" ]; then
+            export PATH="$(cygpath -u "$USERPROFILE")/.cargo/bin:$PATH"
+          fi
           # install inline instead of via an action, which would choose a different HOME on Windows
           if ! command -v cargo > /dev/null; then
             curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal

--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -268,16 +268,11 @@ jobs:
       - name: Build nanoda
         if: matrix.release && !matrix.wasm && inputs.RELEASE_TAG != '' && github.repository == 'leanprover/lean4'
         run: |
-          # msys2 trims the Windows `PATH`, hiding the runner's cargo, and a native rustup installs
-          # to `%USERPROFILE%` rather than to the msys2 `$HOME`
+          # msys2 hides the runner's preinstalled cargo by trimming the Windows `PATH`
           if command -v cygpath > /dev/null && [ -n "${USERPROFILE:-}" ]; then
             export PATH="$(cygpath -u "$USERPROFILE")/.cargo/bin:$PATH"
           fi
-          # install inline instead of via an action, which would choose a different HOME on Windows
-          if ! command -v cargo > /dev/null; then
-            curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal
-            export PATH="$HOME/.cargo/bin:$PATH"
-          fi
+          cargo --version  # fails step if not found
           make -C build/$TARGET_STAGE nanoda
       - name: Install
         run: |

--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -265,6 +265,15 @@ jobs:
           fi
           elan --version  # fails step if not found
           make -C build/$TARGET_STAGE lean4lean
+      - name: Build nanoda
+        if: matrix.release && !matrix.wasm && inputs.RELEASE_TAG != '' && github.repository == 'leanprover/lean4'
+        run: |
+          # install inline instead of via an action, which would choose a different HOME on Windows
+          if ! command -v cargo > /dev/null; then
+            curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal
+            export PATH="$HOME/.cargo/bin:$PATH"
+          fi
+          make -C build/$TARGET_STAGE nanoda
       - name: Install
         run: |
           make -C build/$TARGET_STAGE install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,7 +294,9 @@ jobs:
               {
                 // portable release build: use channel with older glibc (2.26)
                 "name": "Linux release",
-                "os": large ? chonk : "ubuntu-latest",
+                // The self-hosted runner carries a different toolset than the hosted ones, so what
+                // we ship is built on a hosted runner even when it is free.
+                "os": large ? (stamped ? "nscloud-ubuntu-24.04-amd64-8x16" : chonk) : "ubuntu-latest",
                 "release": stamped,
                 // Unstamped builds are published too (`pr-release.yml`, `grove.yml`), so always pack
                 // and upload the artifact.

--- a/LICENSES
+++ b/LICENSES
@@ -1372,8 +1372,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ==============================================================================
-leantar and lean4lean are by Mario Carneiro and distributed under the Apache
-2.0 License:
+leantar and lean4lean are by Mario Carneiro, nanoda is by Chris Bailey; all are
+distributed under the Apache 2.0 License:
 ==============================================================================
                                  Apache License
                            Version 2.0, January 2004

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1045,6 +1045,21 @@ if(NOT CMAKE_SYSTEM_NAME MATCHES "Emscripten")
       ${CMAKE_BINARY_DIR}/bin
   )
 
+  # Not in `ALL` as it's expensive; release CI builds it explicitly.
+  ExternalProject_Add(
+    nanoda
+    PREFIX nanoda
+    EXCLUDE_FROM_ALL ON
+    GIT_REPOSITORY https://github.com/ammkrn/nanoda_lib
+    GIT_TAG 4c544ed4099c8227f07d5de77ad1e69fb0740a27
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND cargo build --release --locked
+    BUILD_IN_SOURCE ON
+    INSTALL_COMMAND
+      ${CMAKE_COMMAND} -E copy target/release/nanoda_bin${CMAKE_EXECUTABLE_SUFFIX}
+      ${CMAKE_BINARY_DIR}/bin
+  )
+
   # Not `ALL` as it's big; release CI builds it explicitly.
   if(USE_MIMALLOC)
     add_custom_target(

--- a/tests/pkg/nanoda/run_test.sh
+++ b/tests/pkg/nanoda/run_test.sh
@@ -1,0 +1,27 @@
+# `nanoda_bin` is bundled into release toolchains only, where the build injects it into `bin/` before
+# installing. Skip rather than fail when absent, so an ordinary test run needs neither the binary nor
+# the network to build it.
+if ! command -v nanoda_bin > /dev/null; then
+    echo "nanoda not built; skipping"
+    exit 0
+fi
+
+# `nanoda_bin` is configured by a JSON file rather than by flags. Its kernel extensions are off by
+# default; turning them on is what exercises its model of Lean's `Nat` and `String` primitives, which
+# drifts silently as Lean's definitions change: `nanoda` keeps building either way. `sorryAx` is
+# exported but never used, so an axiom outside the permitted list must not be fatal, and the
+# default-on axiom listing needs a destination or it is reported as a pretty printer error.
+cat > "$TMP_DIR/config.json" <<'EOF'
+{
+  "use_stdin": true,
+  "permitted_axioms": ["propext", "Classical.choice", "Quot.sound"],
+  "unpermitted_axiom_hard_error": false,
+  "nat_extension": true,
+  "string_extension": true,
+  "pp_to_stdout": true,
+  "print_success_message": true
+}
+EOF
+
+leanexport Init | nanoda_bin "$TMP_DIR/config.json" | tee "$TMP_DIR/out"
+grep -qE '^Checked [1-9][0-9]* declarations with no errors' "$TMP_DIR/out"


### PR DESCRIPTION
This PR bundles the `nanoda` external checker with release toolchains, so it can be used as an independent checker without a separate install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
