### PR TITLE
feat: don't reduce proofs in `is_def_eq_core`

### DIFF
--- a/src/kernel/type_checker.cpp
+++ b/src/kernel/type_checker.cpp
@@ -1145,6 +1145,9 @@ bool type_checker::is_def_eq_core(expr const & t, expr const & s) {
         }
     }
 
+    r = is_def_eq_proof_irrel(t_n, s_n);
+    if (r != l_undef) return r == l_true;
+
     /*
       Apply whnf (without using delta-reduction or normalizer extensions), *and*
       without using `whnf` when reducing projections.
@@ -1159,9 +1162,6 @@ bool type_checker::is_def_eq_core(expr const & t, expr const & s) {
         r = quick_is_def_eq(t_n, s_n);
         if (r != l_undef) return r == l_true;
     }
-
-    r = is_def_eq_proof_irrel(t_n, s_n);
-    if (r != l_undef) return r == l_true;
 
     /* NB: `lazy_delta_reduction` updates `t_n` and `s_n` even when returning `l_undef`. */
     r = lazy_delta_reduction(t_n, s_n);

--- a/src/kernel/type_checker.cpp
+++ b/src/kernel/type_checker.cpp
@@ -1145,7 +1145,7 @@ bool type_checker::is_def_eq_core(expr const & t, expr const & s) {
         }
     }
 
-    r = is_def_eq_proof_irrel(t_n, s_n);
+    r = is_def_eq_proof_irrel(t, s);
     if (r != l_undef) return r == l_true;
 
     /*

--- a/stage0/src/stdlib_flags.h
+++ b/stage0/src/stdlib_flags.h
@@ -1,6 +1,6 @@
 #include "util/options.h"
 
-// [ ] Check box to force CI to test stage 2 and run update-stage0 on PR merge
+// [X] Check box to force CI to test stage 2 and run update-stage0 on PR merge
 // (any other change to this file will do the same; ALL changes should be made to the stage0/ copy)
 
 namespace lean {

--- a/tests/elab/kernel_is_prop_issue.lean
+++ b/tests/elab/kernel_is_prop_issue.lean
@@ -181,8 +181,26 @@ private def expectAccepted (env : Environment) (label : String) (decl : Declarat
   | .error error => throwError "{label}: {error.toMessageData (← getOptions)}"
 
 /--
-error: eager-projection-seed: (kernel) type expected
-  resultSort gateWitness
+info: HISTORY CONTROL eager-projection-seed: accepted; axioms=[]
+---
+info: HISTORY CONTROL seed-then-unlock: accepted; axioms=[]
+---
+info: HISTORY CONTROL honest-Unit-endpoint: accepted; axioms=[propext]
+---
+info: HISTORY TARGET REJECT: (kernel) application type mismatch
+  identityValue Empty ⋯ (identityValue Unit ⋯ ())
+argument has type
+  preserveType Unit
+but function has type
+  preserveType Empty → preserveType Empty
+---
+info: HISTORY UNIT INFERRED: Lean.Expr.forallE
+  `p
+  (Lean.Expr.const `Issue.ModeP [])
+  (Lean.Expr.app (Lean.Expr.const `Issue.preserveType []) (Lean.Expr.const `Unit []))
+  (Lean.BinderInfo.default)
+---
+info: TRANSPORTED HISTORY COMPLETE: candidate rejected; no False
 -/
 #guard_msgs in
 run_meta do


### PR DESCRIPTION
This PR ensures `is_def_eq_proof_irrel` runs before reducing any potential proofs in `is_def_eq_core` rather than after. This is already the order in which things run in the elaborator, so no need for any changes there.

Related to #14977
