### PR TITLE
fix: expose `Fin.addNat?`

### DIFF
--- a/src/Init/Data/Fin/OverflowAware.lean
+++ b/src/Init/Data/Fin/OverflowAware.lean
@@ -22,7 +22,7 @@ Examples:
 * {lean}`(2 : Fin 3).addNat? 1 = (none : Option (Fin 3))`
 * {lean}`(2 : Fin 4).addNat? 1 = (some 3 : Option (Fin 4))`
 -/
-@[inline]
+@[inline, expose]
 protected def addNat? (i : Fin n) (m : Nat) : Option (Fin n) :=
   if h : i + m < n then some ⟨i + m, h⟩ else none
 

--- a/tests/elab/fin_addNat_module.lean
+++ b/tests/elab/fin_addNat_module.lean
@@ -1,0 +1,14 @@
+module
+
+/-!
+Tests reduction of `Fin.addNat?`, and of the polymorphic ranges built from it, across a module
+boundary.
+-/
+
+example : ((2 : Fin 4).addNat? 1) = some 3 := by cbv
+
+example : ((2 : Fin 3).addNat? 1) = none := by cbv
+
+example : (1...4).toList.map (@Fin.succ 7) = (2...5).toList := by cbv
+
+example : ((2 : Fin 4).addNat? 1) = some 3 := by decide +kernel


### PR DESCRIPTION
This PR exposes `Fin.addNat?`, so that it reduces across module boundaries. Ranges over `Fin n` are built from it via the `UpwardEnumerable (Fin n)` instance, so previously `cbv` and kernel reduction got stuck on `Fin.addNat?` applications in any file using the module system.

Reported at https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/Expose.20.60Fin.2EaddNat.3F.60/near/623301603.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nm1fU98wnyeSGaj36QuvA