### PR TITLE
fix: expose the `Char.ordinal` family

### DIFF
--- a/src/Init/Data/Char/Ordinal.lean
+++ b/src/Init/Data/Char/Ordinal.lean
@@ -54,6 +54,7 @@ greater than the surrogate code points by the number of surrogate code points.
 
 The inverse of this function is called {name (scope := "Init.Data.Char.Ordinal")}`Char.ofOrdinal`.
 -/
+@[expose]
 def ordinal (c : Char) : Fin Char.numCodePoints :=
   if h : c.val < 0xd800 then
     ⟨c.val.toNat, by grind [UInt32.lt_iff_toNat_lt]⟩
@@ -66,6 +67,7 @@ greater than the surrogate code points by the number of surrogate code points.
 
 The inverse of this function is called {name}`Char.ordinal`.
 -/
+@[expose]
 def ofOrdinal (f : Fin Char.numCodePoints) : Char :=
   if h : (f : Nat) < 0xd800 then
     ⟨UInt32.ofNatLT f (by grind), by grind [UInt32.toNat_ofNatLT]⟩
@@ -79,6 +81,7 @@ Computes the next {name}`Char`, skipping over surrogate code points (which are n
 This function is specified by its interaction with {name}`Char.ordinal`, see
 {name (scope := "Init.Data.Char.Ordinal")}`Char.succ?_eq`.
 -/
+@[expose]
 def succ? (c : Char) : Option Char :=
   if h₀ : c.val < 0xd7ff then
     some ⟨c.val + 1, by grind [UInt32.lt_iff_toNat_lt, UInt32.toNat_add]⟩
@@ -98,6 +101,7 @@ valid {name}`Char`s) as necessary.
 This function is specified by its interaction with {name}`Char.ordinal`, see
 {name (scope := "Init.Data.Char.Ordinal")}`Char.succMany?_eq`.
 -/
+@[expose]
 def succMany? (m : Nat) (c : Char) : Option Char :=
   c.ordinal.addNat? m |>.map Char.ofOrdinal
 

--- a/tests/elab/char_ordinal_module.lean
+++ b/tests/elab/char_ordinal_module.lean
@@ -1,0 +1,26 @@
+module
+
+/-!
+Tests reduction of the `Char.ordinal` family, and of the polymorphic ranges built from it, across a
+module boundary.
+-/
+
+example : 'a'.ordinal.val = 97 := by cbv
+
+example : Char.ofOrdinal ⟨97, by decide⟩ = 'a' := by cbv
+
+example : 'a'.succ? = some 'b' := by cbv
+
+example : 'a'.succMany? 2 = some 'c' := by cbv
+
+example : ('a'...='c').toList = ['a', 'b', 'c'] := by cbv
+
+-- The surrogate code points are skipped over.
+example : (Char.ofNat 0xd7ff).succ? = some (Char.ofNat 0xe000) := by cbv
+
+example : (Char.ofNat 0xd7ff).ordinal.val + 1 = (Char.ofNat 0xe000).ordinal.val := by cbv
+
+-- `Char.succ?` overflows at the last code point.
+example : (Char.ofNat 0x10ffff).succ? = none := by cbv
+
+example : 'a'.ordinal.val = 97 := by decide +kernel


### PR DESCRIPTION
This PR exposes `Char.ordinal`, `Char.ofOrdinal`, `Char.succ?` and `Char.succMany?`, so that they reduce across module boundaries. Ranges over `Char` are built from `Char.succ?` and `Char.succMany?` via the `UpwardEnumerable Char` instance, so previously `cbv` and kernel reduction got stuck on these in any file using the module system.

All four are needed together: `Char.succMany?` goes through `Char.ordinal` and `Option.map Char.ofOrdinal`, so exposing only the successor functions still leaves successful results stuck.

Follows https://github.com/leanprover/lean4/pull/15114, which did the same for `Fin.addNat?`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)