### PR TITLE
feat: accept a `[...]` parameter list in `lia` and `grobner`

### DIFF
--- a/src/Init/Grind/Tactics.lean
+++ b/src/Init/Grind/Tactics.lean
@@ -358,7 +358,8 @@ It is a implemented as a thin wrapper around the `grind` tactic, enabling only t
 Please use `grind` instead if you need additional capabilities.
 
 Like `grind`, it accepts a list of extra facts, e.g. `grobner [foo x y]`. Since `grobner` does not
-run E-matching, quantified lemmas passed this way are only instantiated when `ematch` is enabled.
+run E-matching by default, quantified lemmas are only instantiated when it is enabled explicitly,
+e.g. `grobner (ematch := 1) [= foo]`.
 -/
 syntax (name := grobner) "grobner" optConfig (" [" withoutPosition(grindParam,*) "]")? : tactic
 

--- a/src/Init/Grind/Tactics.lean
+++ b/src/Init/Grind/Tactics.lean
@@ -358,7 +358,8 @@ It is a implemented as a thin wrapper around the `grind` tactic, enabling only t
 Please use `grind` instead if you need additional capabilities.
 
 Like `grind`, it accepts a list of extra facts and lemmas, e.g. `grobner [foo x y, = bar]`.
-Lemmas given this way are instantiated via E-matching, while the `@[grind]` lemma set stays disabled.
+Lemmas given this way are instantiated via E-matching, while the `@[grind]` lemma set is not enabled
+implicitly.
 -/
 syntax (name := grobner) "grobner" optConfig (" [" withoutPosition(grindParam,*) "]")? : tactic
 

--- a/src/Init/Grind/Tactics.lean
+++ b/src/Init/Grind/Tactics.lean
@@ -329,8 +329,10 @@ syntax (name := cutsat) "cutsat" optConfig : tactic
 
 It is a implemented as a thin wrapper around the `grind` tactic, enabling only the `lia` solver.
 Please use `grind` instead if you need additional capabilities.
+
+Like `grind`, it accepts a list of extra facts and lemmas, e.g. `lia [foo n, = bar]`.
 -/
-syntax (name := lia) "lia" optConfig : tactic
+syntax (name := lia) "lia" optConfig (" [" withoutPosition(grindParam,*) "]")? : tactic
 
 /--
 `grind_order` solves simple goals about partial orders and linear orders.
@@ -354,8 +356,11 @@ over commutative (semi)rings, using the Grobner basis algorithm.
 
 It is a implemented as a thin wrapper around the `grind` tactic, enabling only the `grobner` solver.
 Please use `grind` instead if you need additional capabilities.
+
+Like `grind`, it accepts a list of extra facts, e.g. `grobner [foo x y]`. Since `grobner` does not
+run E-matching, quantified lemmas passed this way are only instantiated when `ematch` is enabled.
 -/
-syntax (name := grobner) "grobner" optConfig : tactic
+syntax (name := grobner) "grobner" optConfig (" [" withoutPosition(grindParam,*) "]")? : tactic
 
 /-!
 Sets symbol priorities for the E-matching pattern inference procedure used in `grind`

--- a/src/Init/Grind/Tactics.lean
+++ b/src/Init/Grind/Tactics.lean
@@ -357,9 +357,8 @@ over commutative (semi)rings, using the Grobner basis algorithm.
 It is a implemented as a thin wrapper around the `grind` tactic, enabling only the `grobner` solver.
 Please use `grind` instead if you need additional capabilities.
 
-Like `grind`, it accepts a list of extra facts, e.g. `grobner [foo x y]`. Since `grobner` does not
-run E-matching by default, quantified lemmas are only instantiated when it is enabled explicitly,
-e.g. `grobner (ematch := 1) [= foo]`.
+Like `grind`, it accepts a list of extra facts and lemmas, e.g. `grobner [foo x y, = bar]`.
+Lemmas given this way are instantiated via E-matching, while the `@[grind]` lemma set stays disabled.
 -/
 syntax (name := grobner) "grobner" optConfig (" [" withoutPosition(grindParam,*) "]")? : tactic
 

--- a/src/Lean/Elab/Tactic/Grind/Main.lean
+++ b/src/Lean/Elab/Tactic/Grind/Main.lean
@@ -485,10 +485,11 @@ def evalGrindTraceCore (stx : Syntax) (trace := true) (verbose := true) (useSorr
 @[builtin_tactic Lean.Parser.Tactic.grobner] def evalGrobner : Tactic := fun stx => do
   let `(tactic| grobner $config:optConfig $[ [$params:grindParam,*] ]?) := stx | throwUnsupportedSyntax
   if params.isSome then
-    -- With explicit lemmas, E-match over them alone: use the `only` extension state so the
-    -- `@[grind]` set stays off, and cap local instantiation as `lia` does.
+    -- Enable E-matching for the supplied lemmas without the `@[grind]` E-matching rules, and
+    -- disable local-theorem E-matching as `lia` does. Other `@[grind]` data (e.g. `inj`) is kept.
     let config ← elabGrobnerConfig config (init := { ematch := ({} : Grind.Config).ematch, genLocal := 0 })
-    evalGrindCore stx { config with } none params none (extensions? := some #[← Grind.getOnlyExtensionState])
+    let ext := { (← Grind.getDefaultExtensionState) with ematch := {} }
+    evalGrindCore stx { config with } none params none (extensions? := some #[ext])
   else
     let config ← elabGrobnerConfig config
     evalGrindCore stx { config with } none params none

--- a/src/Lean/Elab/Tactic/Grind/Main.lean
+++ b/src/Lean/Elab/Tactic/Grind/Main.lean
@@ -484,7 +484,13 @@ def evalGrindTraceCore (stx : Syntax) (trace := true) (verbose := true) (useSorr
 
 @[builtin_tactic Lean.Parser.Tactic.grobner] def evalGrobner : Tactic := fun stx => do
   let `(tactic| grobner $config:optConfig $[ [$params:grindParam,*] ]?) := stx | throwUnsupportedSyntax
-  let config ← elabGrobnerConfig config
-  evalGrindCore stx { config with } none params none
+  if params.isSome then
+    -- With explicit lemmas, E-match over them alone: use the `only` extension state so the
+    -- `@[grind]` set stays off, and cap local instantiation as `lia` does.
+    let config ← elabGrobnerConfig config (init := { ematch := ({} : Grind.Config).ematch, genLocal := 0 })
+    evalGrindCore stx { config with } none params none (extensions? := some #[← Grind.getOnlyExtensionState])
+  else
+    let config ← elabGrobnerConfig config
+    evalGrindCore stx { config with } none params none
 
 end Lean.Elab.Tactic

--- a/src/Lean/Elab/Tactic/Grind/Main.lean
+++ b/src/Lean/Elab/Tactic/Grind/Main.lean
@@ -455,10 +455,10 @@ def evalGrindTraceCore (stx : Syntax) (trace := true) (verbose := true) (useSorr
     Tactic.TryThis.addSuggestions stx <| tacs.map fun tac => { suggestion := .tsyntax tac }
 
 @[builtin_tactic Lean.Parser.Tactic.lia] def evalLia : Tactic := fun stx => do
-  let `(tactic| lia $config:optConfig) := stx | throwUnsupportedSyntax
+  let `(tactic| lia $config:optConfig $[ [$params:grindParam,*] ]?) := stx | throwUnsupportedSyntax
   let config ← elabCutsatConfig config
   let extensions ← Grind.getLiaExtensions
-  evalGrindCore stx { config with } none none none (extensions? := some extensions)
+  evalGrindCore stx { config with } none params none (extensions? := some extensions)
 
 @[builtin_tactic Lean.Parser.Tactic.cutsat] def evalCutsat : Tactic := fun stx => do
   let `(tactic| cutsat $config:optConfig) := stx | throwUnsupportedSyntax
@@ -483,8 +483,8 @@ def evalGrindTraceCore (stx : Syntax) (trace := true) (verbose := true) (useSorr
   evalGrindCore stx { config with } none none none
 
 @[builtin_tactic Lean.Parser.Tactic.grobner] def evalGrobner : Tactic := fun stx => do
-  let `(tactic| grobner $config:optConfig) := stx | throwUnsupportedSyntax
+  let `(tactic| grobner $config:optConfig $[ [$params:grindParam,*] ]?) := stx | throwUnsupportedSyntax
   let config ← elabGrobnerConfig config
-  evalGrindCore stx { config with } none none none
+  evalGrindCore stx { config with } none params none
 
 end Lean.Elab.Tactic

--- a/src/Lean/Elab/Tactic/Grind/Param.lean
+++ b/src/Lean/Elab/Tactic/Grind/Param.lean
@@ -34,8 +34,7 @@ def _root_.Lean.Meta.Grind.Params.isInjectiveTheorem (params : Grind.Params) (de
   params.extensions.any fun ext => ext.inj.contains (.decl declName)
 
 def _root_.Lean.Meta.Grind.Params.eraseEMatchCore (params : Grind.Params) (declName : Name) : Grind.Params :=
-  -- Erase from every extension state, not just the first: `lia` keeps the `@[lia]` set in a separate slot.
-  { params with extensions := params.extensions.map fun ext => { ext with ematch := ext.ematch.erase (.decl declName) } }
+  { params with extensions := params.extensions.modify 0 fun ext => { ext with ematch := ext.ematch.erase (.decl declName) } }
 
 def _root_.Lean.Meta.Grind.Params.eraseEMatch (params : Grind.Params) (declName : Name) : MetaM Grind.Params := do
   if !wasOriginallyTheorem (← getEnv) declName then

--- a/src/Lean/Elab/Tactic/Grind/Param.lean
+++ b/src/Lean/Elab/Tactic/Grind/Param.lean
@@ -34,7 +34,8 @@ def _root_.Lean.Meta.Grind.Params.isInjectiveTheorem (params : Grind.Params) (de
   params.extensions.any fun ext => ext.inj.contains (.decl declName)
 
 def _root_.Lean.Meta.Grind.Params.eraseEMatchCore (params : Grind.Params) (declName : Name) : Grind.Params :=
-  { params with extensions := params.extensions.modify 0 fun ext => { ext with ematch := ext.ematch.erase (.decl declName) } }
+  -- Erase from every extension state, not just the first: `lia` keeps the `@[lia]` set in a separate slot.
+  { params with extensions := params.extensions.map fun ext => { ext with ematch := ext.ematch.erase (.decl declName) } }
 
 def _root_.Lean.Meta.Grind.Params.eraseEMatch (params : Grind.Params) (declName : Name) : MetaM Grind.Params := do
   if !wasOriginallyTheorem (← getEnv) declName then

--- a/tests/elab/lia_grobner_params.lean
+++ b/tests/elab/lia_grobner_params.lean
@@ -1,7 +1,7 @@
 /-!
 # `lia` and `grobner` accept a `[...]` parameter list
 
-Both tactics are thin wrappers around `grind`, and take the same `[...]` term list. Proof
+Both tactics are thin wrappers around `grind`, and take the same `[...]` parameter list. Proof
 terms are asserted as extra facts, and lemmas are added to the E-matching lemma set.
 -/
 
@@ -28,10 +28,19 @@ example (n : Nat) : 1 ≤ f n + f (n + 1) := by
 example (n : Int) : 0 ≤ clamp n := by
   lia -order [= clamp_def]
 
+-- Naming a `grind` attribute adds its whole lemma set, so `@[grind]`-only lemmas become visible.
+private def g (n : Int) : Int := n + 1
+@[grind =] private theorem g_def (n : Int) : g n = n + 1 := rfl
+example (n : Int) : g n = n + 1 := by
+  fail_if_success lia
+  lia [grind]
+
 -- `-` removes a lemma from the `@[lia]` set.
 example (a b : Nat) (h : a ≤ b) : max a b = b := by
   fail_if_success lia [- Nat.max_def]
   lia
+example (a b : Nat) (h : a ≤ b) : min a b = a := by
+  lia [- Nat.max_def]
 
 -- `grobner` accepts proof terms as extra facts.
 private def sq (x : Int) : Int := x * x
@@ -42,6 +51,11 @@ example (x y : Int) (h : x = y) : sq x = y * y := by
 
 example (x y : Int) (h : x + y = 0) : sq x = sq y := by
   grobner [sq_def x, sq_def y]
+
+-- `grobner` does not run E-matching by default, so a quantified lemma is inert unless enabled.
+example (x y : Int) (h : x = y) : sq x = y * y := by
+  fail_if_success grobner [= sq_def]
+  grobner (ematch := 1) [= sq_def]
 
 -- Local hypotheses are used automatically, so passing one is an error, as for `grind`.
 /-- error: redundant parameter `h`, `grind` uses local hypotheses automatically -/

--- a/tests/elab/lia_grobner_params.lean
+++ b/tests/elab/lia_grobner_params.lean
@@ -59,7 +59,15 @@ example (n : Int) : g n = n + 1 := by
   fail_if_success grobner [= sq_def]
   grobner [= g_def]
 
--- Local hypotheses are used automatically, so passing one is an error, as for `grind`.
+-- `@[grind inj]` theorems remain available with a parameter list.
+private opaque F : Int → Int
+@[grind inj] private axiom F_inj : Function.Injective F
+example (x y : Int) (h : F x = F y) : x = y := by
+  grobner
+example (x y : Int) (h : F x = F y) : x = y := by
+  grobner []
+
+-- Ordinary local facts are used automatically, so passing one is an error, as for `grind`.
 /-- error: redundant parameter `h`, `grind` uses local hypotheses automatically -/
 #guard_msgs in
 example (x y : Int) (h : x = y) : x * x = y * y := by

--- a/tests/elab/lia_grobner_params.lean
+++ b/tests/elab/lia_grobner_params.lean
@@ -52,10 +52,12 @@ example (x y : Int) (h : x = y) : sq x = y * y := by
 example (x y : Int) (h : x + y = 0) : sq x = sq y := by
   grobner [sq_def x, sq_def y]
 
--- `grobner` does not run E-matching by default, so a quantified lemma is inert unless enabled.
+-- Quantified lemmas are instantiated via E-matching, while the `@[grind]` set stays disabled.
 example (x y : Int) (h : x = y) : sq x = y * y := by
+  grobner [= sq_def]
+example (n : Int) : g n = n + 1 := by
   fail_if_success grobner [= sq_def]
-  grobner (ematch := 1) [= sq_def]
+  grobner [= g_def]
 
 -- Local hypotheses are used automatically, so passing one is an error, as for `grind`.
 /-- error: redundant parameter `h`, `grind` uses local hypotheses automatically -/

--- a/tests/elab/lia_grobner_params.lean
+++ b/tests/elab/lia_grobner_params.lean
@@ -1,0 +1,50 @@
+/-!
+# `lia` and `grobner` accept a `[...]` parameter list
+
+Both tactics are thin wrappers around `grind`, and take the same `[...]` term list. Proof
+terms are asserted as extra facts, and lemmas are added to the E-matching lemma set.
+-/
+
+private def clamp (n : Int) : Int := if n ≤ 0 then 0 else n
+private theorem clamp_def (n : Int) : clamp n = if n ≤ 0 then 0 else n := rfl
+
+-- Without extra facts, `lia` treats `clamp` as opaque and cannot finish.
+example (n : Int) : 0 ≤ clamp n := by
+  fail_if_success lia
+  lia [clamp_def n]
+
+-- A quantified lemma is instantiated via E-matching, as in `grind`.
+example (n : Int) : 0 ≤ clamp n := by
+  lia [= clamp_def]
+
+-- Arguments can be arbitrary proof terms.
+private opaque f : Nat → Nat
+private axiom f_pos (n : Nat) : 0 < f n
+example (n : Nat) : 1 ≤ f n + f (n + 1) := by
+  fail_if_success lia
+  lia [f_pos n, f_pos (n + 1)]
+
+-- Config options still combine with the parameter list.
+example (n : Int) : 0 ≤ clamp n := by
+  lia -order [= clamp_def]
+
+-- `-` removes a lemma from the `@[lia]` set.
+example (a b : Nat) (h : a ≤ b) : max a b = b := by
+  fail_if_success lia [- Nat.max_def]
+  lia
+
+-- `grobner` accepts proof terms as extra facts.
+private def sq (x : Int) : Int := x * x
+private theorem sq_def (x : Int) : sq x = x * x := rfl
+example (x y : Int) (h : x = y) : sq x = y * y := by
+  fail_if_success grobner
+  grobner [sq_def x]
+
+example (x y : Int) (h : x + y = 0) : sq x = sq y := by
+  grobner [sq_def x, sq_def y]
+
+-- Local hypotheses are used automatically, so passing one is an error, as for `grind`.
+/-- error: redundant parameter `h`, `grind` uses local hypotheses automatically -/
+#guard_msgs in
+example (x y : Int) (h : x = y) : x * x = y * y := by
+  grobner [h]


### PR DESCRIPTION
This PR lets `lia` and `grobner` take the same `[...]` parameter list as `grind`, so extra facts and lemmas can be supplied inline (e.g. `lia [foo n]` or `grobner [= sq_def]`) instead of first adding them to the local context with `have`.

Both tactics call the shared `grind` entry point, which already accepted a parameter list; the wrappers simply did not parse one. Proof terms are asserted as extra facts and quantified lemmas are added to the E-matching set. For `lia`, E-matching already runs over the `@[lia]` set, so `lia [= foo]` instantiates `foo`, and naming a `grind` attribute adds its whole lemma set, e.g. `lia [grind]`. `grobner` normally runs without E-matching; when given a parameter list it enables E-matching for the supplied lemmas without the `@[grind]` E-matching rules (other `@[grind]` data such as injectivity theorems is kept) and disables local-theorem E-matching as `lia` does. Without a parameter list `grobner` is unchanged.

Context: https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/Give.20terms.20to.20.60grobner.60.20or.20.60lia.60.3F/near/621650561

🤖 Generated with [Claude Code](https://claude.com/claude-code)
