### PR TITLE
chore: ci: update `grove-action` to v0.6

### DIFF
--- a/.github/workflows/grove.yml
+++ b/.github/workflows/grove.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Fetch upstream invalidated facts
         if: ${{ steps.should-run.outputs.should-run == 'true' && steps.workflow-info.outputs.pullRequestNumber != '' }}
         id: fetch-upstream
-        uses: TwoFx/grove-action/fetch-upstream@v0.5
+        uses: TwoFx/grove-action/fetch-upstream@v0.6
         with:
           artifact-name: grove-invalidated-facts
           base-ref: master
@@ -97,13 +97,12 @@ jobs:
       - name: Build
         if: ${{ steps.should-run.outputs.should-run == 'true' }}
         id: build
-        uses: TwoFx/grove-action/build@v0.5
+        uses: TwoFx/grove-action/build@v0.6
         with:
           project-path: doc/std/grove
           script-name: grove-stdlib
           invalidated-facts-artifact-name: grove-invalidated-facts
           comment-artifact-name: grove-comment
-          toolchain-id: lean4
           toolchain-path: artifacts/${{ steps.unpack-toolchain.outputs.lean-dir }}
           project-ref: ${{ steps.workflow-info.outputs.sourceHeadSha }}
 


### PR DESCRIPTION
This PR updates the Grove action to the latest version which is adapted to the fact that we switched to relative toolchains at some point.

As usual, we'll have to test this on master since GitHub will not actually use the changed workflow until it is on master.