### PR TITLE
chore: missing order instances for `UIntX` and `IntX`

### DIFF
--- a/src/Init/Data/Int/Package.lean
+++ b/src/Init/Data/Int/Package.lean
@@ -9,14 +9,11 @@ prelude
 public import Init.Data.Order.PackageFactories
 import Init.Data.Int.Order
 import Init.Data.Int.Compare
-import Init.Data.Order.Lemmas
 
 open Std
 
 namespace Int
 
-public instance : LinearOrderPackage Int := .ofLE _ {
-  beq_iff_le_and_ge a b := by simpa using Int.le_antisymm_iff
-}
+public instance : LinearOrderPackage Int := .ofLE _ { }
 
 end Int

--- a/src/Init/Data/Nat/Package.lean
+++ b/src/Init/Data/Nat/Package.lean
@@ -9,7 +9,6 @@ prelude
 public import Init.Data.Order.PackageFactories
 import Init.Data.Nat.Order
 import Init.Data.Nat.Compare
-import Init.Data.Order.Lemmas
 
 open Std
 

--- a/src/Init/Data/Ord/Basic.lean
+++ b/src/Init/Data/Ord/Basic.lean
@@ -290,6 +290,8 @@ theorem isLE_then_iff_and : ∀ {o₁ o₂ : Ordering}, (o₁.then o₂).isLE �
 theorem isLE_left_of_isLE_then : ∀ {o₁ o₂ : Ordering}, (o₁.then o₂).isLE → o₁.isLE := by decide
 theorem isGE_left_of_isGE_then : ∀ {o₁ o₂ : Ordering}, (o₁.then o₂).isGE → o₁.isGE := by decide
 
+theorem isLE_and_isGE_eq : ∀ {o : Ordering}, (o.isLE && o.isGE) = o.isEq := by decide
+
 instance : Std.Associative Ordering.then := ⟨then_assoc⟩
 instance : Std.IdempotentOp Ordering.then := ⟨fun _ => then_self⟩
 

--- a/src/Init/Data/Order/Lemmas.lean
+++ b/src/Init/Data/Order/Lemmas.lean
@@ -452,6 +452,21 @@ public instance {α : Type u} [LE α] [Min α] [IsLinearPreorder α] [LawfulOrde
         exact fun hac => le_trans hac (by simpa [hbc] using Std.le_total (a := b) (b := c))
     split <;> simp [*, LawfulOrderLeftLeaningMin.min_eq_left, LawfulOrderLeftLeaningMin.min_eq_right]
 
+section minOfLe
+
+public theorem min_eq_of_minOfLe {α : Type u} [LE α] [DecidableLE α] {a b : α} :
+    letI : Min α := minOfLe
+    min a b = if a ≤ b then a else b :=
+  rfl
+
+public instance lawfulOrderLeftLeaningMin_minOfLe {α : Type u} [LE α] [DecidableLE α] :
+    letI : Min α := minOfLe
+    Std.LawfulOrderLeftLeaningMin α := by
+  let : Min α := minOfLe
+  exact ⟨fun _ _ h => by simp [h, min_eq_of_minOfLe], fun _ _ h => by simp [h, min_eq_of_minOfLe]⟩
+
+end minOfLe
+
 end Min
 end Std
 
@@ -598,6 +613,26 @@ public instance {α : Type u} [LE α] [Max α] [IsLinearPreorder α] [LawfulOrde
       · simp only [iff_and_self]
         exact fun hbc => le_trans (by simpa [hba] using Std.le_total (a := b) (b := a)) hbc
     split <;> simp [*, LawfulOrderLeftLeaningMax.max_eq_left, LawfulOrderLeftLeaningMax.max_eq_right]
+
+section maxOfLe
+
+public theorem max_eq_of_maxOfLe {α : Type u} [LE α] [DecidableLE α] {a b : α} :
+    letI : Max α := maxOfLe
+    max a b = if a ≤ b then b else a :=
+  rfl
+
+public instance lawfulOrderSup_maxOfLe {α : Type u} [LE α] [DecidableLE α]
+    [Trans (α := α) (· ≤ ·) (· ≤ ·) (· ≤ ·)] [Std.Total (α := α) (· ≤ ·)] :
+    letI : Max α := maxOfLe
+    Std.LawfulOrderSup α := by
+  let : Max α := maxOfLe
+  refine ⟨fun a b c => ?_⟩
+  rw [max_eq_of_maxOfLe]
+  split <;> rename_i h
+  · exact ⟨fun h' => ⟨le_trans h h', h'⟩, (·.2)⟩
+  · exact ⟨fun h' => ⟨h', le_trans (le_of_not_ge h) h'⟩, (·.1)⟩
+
+end maxOfLe
 
 end Max
 end Std

--- a/src/Init/Data/Order/LemmasExtra.lean
+++ b/src/Init/Data/Order/LemmasExtra.lean
@@ -170,6 +170,13 @@ theorem min_le_min [LE α] [Min α] [Std.LawfulOrderLeftLeaningMin α] [IsLinear
 public instance [LE α] [Min α] [Std.LawfulOrderLeftLeaningMin α] [IsLinearOrder α] : Commutative (min : α → α → α) where
   comm a b := by apply le_antisymm <;> simp [min_le_min]
 
+public instance [BEq α] [Ord α] [LE α] [Std.LawfulBEqOrd α] [Std.LawfulOrderOrd α] :
+    Std.LawfulOrderBEq α where
+  beq_iff_le_and_ge a b := by
+    rw [← Std.LawfulBEqOrd.compare_eq_iff_beq, ← Ordering.isEq_iff_eq_eq,
+      ← Ordering.isLE_and_isGE_eq, Bool.and_eq_true, Std.LawfulOrderOrd.isGE_compare,
+      Std.LawfulOrderOrd.isLE_compare]
+
 end Std
 
 namespace Classical.Order

--- a/src/Init/Data/Order/PackageFactories.lean
+++ b/src/Init/Data/Order/PackageFactories.lean
@@ -9,8 +9,8 @@ prelude
 public import Init.Data.Order.LemmasExtra  -- shake: keep (instance inlined by `haveI`)
 public import Init.Data.Order.FactoriesExtra
 public import Init.Data.Order.Factories -- shake: keep (autoparam filling `Min.leftLeaningOfLE`)
+public import Init.Data.Order.Lemmas -- shake: keep (everyone applying these factories needs this)
 import Init.Data.Bool
-import Init.Data.Order.Lemmas
 
 namespace Std
 

--- a/src/Init/Data/SInt.lean
+++ b/src/Init/Data/SInt.lean
@@ -12,6 +12,7 @@ public import Init.Data.SInt.Float32
 public import Init.Data.SInt.Lemmas
 public import Init.Data.SInt.Bitwise
 public import Init.Data.SInt.IntToBitVec
+public import Init.Data.SInt.Package
 
 public section
 

--- a/src/Init/Data/SInt/Package.lean
+++ b/src/Init/Data/SInt/Package.lean
@@ -1,0 +1,19 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Julia M. Himmel
+-/
+module
+
+prelude
+public import Init.Data.Order.PackageFactories
+import Init.Data.SInt.Lemmas
+import Init.Data.Ord.SInt
+
+open Std
+
+instance : Std.LinearOrderPackage Int8 := .ofLE _ { }
+instance : Std.LinearOrderPackage Int16 := .ofLE _ { }
+instance : Std.LinearOrderPackage Int32 := .ofLE _ { }
+instance : Std.LinearOrderPackage Int64 := .ofLE _ { }
+instance : Std.LinearOrderPackage ISize := .ofLE _ { }

--- a/src/Init/Data/UInt.lean
+++ b/src/Init/Data/UInt.lean
@@ -12,3 +12,4 @@ public import Init.Data.UInt.Log2
 public import Init.Data.UInt.Lemmas
 public import Init.Data.UInt.Bitwise
 public import Init.Data.UInt.IntToBitVec
+public import Init.Data.UInt.Package

--- a/src/Init/Data/UInt/Package.lean
+++ b/src/Init/Data/UInt/Package.lean
@@ -1,0 +1,19 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Julia M. Himmel
+-/
+module
+
+prelude
+public import Init.Data.Order.PackageFactories
+import Init.Data.UInt.Lemmas
+import Init.Data.Ord.UInt
+
+open Std
+
+instance : Std.LinearOrderPackage UInt8 := .ofLE _ { }
+instance : Std.LinearOrderPackage UInt16 := .ofLE _ { }
+instance : Std.LinearOrderPackage UInt32 := .ofLE _ { }
+instance : Std.LinearOrderPackage UInt64 := .ofLE _ { }
+instance : Std.LinearOrderPackage USize := .ofLE _ { }


### PR DESCRIPTION
This PR adds the missing order instances on `UIntX` and `IntX`.

Indeed, the corresponding `LinearOrderPackage`s can all be constructed automatically after adding a few general nonsense instances.

Co-Authored-By: Robin Arnez <152706811+Rob23oba@users.noreply.github.com>