### PR TITLE
chore: ci: move `macOS aarch64` from merge queue to master check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,7 +377,9 @@ jobs:
               },
               {
                 "name": "macOS aarch64",
-                "enabled": level >= 1 || macos_arm,
+                // Kept out of the merge queue, where it would be the slowest job; breakage surfaces
+                // on master instead.
+                "enabled": isPushToMaster || level >= 2 || macos_arm,
                 "test": level >= 2,
                 // standard GH runner only comes with 7GB so use large runner if possible when running tests
                 "os": large && (fast || level >= 2) ? "nscloud-macos-sequoia-arm64-6x14" : "macos-15",


### PR DESCRIPTION
This PR stops running the `macOS aarch64` build in the merge queue and on `merge-ci` PRs, which mirror it, and runs it on pushes to `master` instead. Nightlies and `macos-arm-ci` PRs keep running it as before. It was the last job to finish in 78% of recent merge queue runs, taking a median 26 minutes against 13 for `Linux release` on the self-hosted runner, so a merge queue run should take about half as long. A macOS-only build failure is now reported on `master` rather than blocking the merge.