### PR TITLE
fix: do not hoist `Decidable` values in `pullInstances`

### DIFF
--- a/src/Lean/Compiler/LCNF/PullLetDecls.lean
+++ b/src/Lean/Compiler/LCNF/PullLetDecls.lean
@@ -109,6 +109,10 @@ def Decl.pullInstances (decl : Decl .pure) : CompilerM (Decl .pure) :=
       if args.any (· == .erased) then return false
     if let .fvar _ args := letDecl.value then
       if args.any (· == .erased) then return false
+    -- A saturated `Decidable` is the outcome of running a decision procedure rather than a
+    -- dictionary, so pulling it out of a branch or lambda would run the procedure unconditionally.
+    if letDecl.type.isAppOf ``Decidable then
+      return false
     if (← isClass? letDecl.type).isSome then
       return true
     else if let .proj _ _ fvarId := letDecl.value then

--- a/tests/elab/pullInstancesDecidable.lean
+++ b/tests/elab/pullInstancesDecidable.lean
@@ -1,0 +1,46 @@
+/-!
+`pullInstances` must not hoist a `Decidable` value out of the branch or thunk it occurs in: the
+value is the result of running a decision procedure, so hoisting it runs the procedure where the
+source does not. Since #8309 turned `if` into a `cases` on `Bool`, `if` branches are affected too.
+-/
+
+inductive T where
+  | leaf (n : Nat)
+  | node (l r : T)
+deriving DecidableEq
+
+/-- `instDecidableEqT`, announcing each run of the decision procedure. -/
+def noisy (a b : T) : Decidable (a = b) :=
+  dbg_trace "decided"; instDecidableEqT a b
+
+/--
+info: decided
+---
+info: false
+-/
+#guard_msgs in
+#eval (noisy (.leaf 1) (.leaf 2)).decide
+
+@[inline] def withAddr {β : Type} [Subsingleton β] (a : T) (k : USize → β) : β :=
+  withPtrAddr a k (fun _ _ => Subsingleton.elim _ _)
+
+@[inline] def ptrDec (a b : T) : Decidable (a = b) :=
+  withPtrEqDecEq a b (fun _ => noisy a b)
+
+/-- The shape of a hash-consing equality test: decide by pointer first. -/
+def viaAddr (a b : @& T) : Decidable (a = b) :=
+  withAddr a fun pa => withAddr b fun pb =>
+    if pa == pb then ptrDec a b else instDecidableEqT a b
+
+/-- info: false -/
+#guard_msgs in
+#eval (viaAddr (.leaf 1) (.leaf 2)).decide
+
+@[noinline] def ignore (_ : Unit → Bool) : Bool := true
+
+def viaThunk (a b : T) : Bool :=
+  ignore fun _ => (noisy a b).decide
+
+/-- info: true -/
+#guard_msgs in
+#eval viaThunk (.leaf 1) (.leaf 2)


### PR DESCRIPTION
This PR stops the compiler from hoisting a `Decidable` value out of the branch or thunk it occurs in, which ran the decision procedure even where the source does not. Since #8309 this also affected `if` branches, so for example the pointer-equality shortcut of a hash-consing equality test ran its structural fallback on every comparison.

`pullInstances` pulls every `let` of class type out of `cases` alternatives and lambdas, assuming it is a cheap dictionary. A saturated `Decidable` is instead the outcome of a decision procedure. Lifting out of a `cases` on `Decidable` used to be disabled, which kept such values inside `if` branches as a side effect; #8309 removed that guard once `if` became a `cases` on `Bool`. Lambdas were never covered, so a `Unit` thunk guarding a decision procedure already had it evaluated eagerly.