### PR TITLE
chore: keep configure's jj fallback from snapshotting the working copy

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -682,12 +682,14 @@ execute_process(
 # Fallback for jj workspaces where git cannot find .git directly.
 # Use `jj git root` to find the backing git repo, then `jj log` to
 # resolve the current workspace's commit (git HEAD points to the root
-# workspace, not the current one).
+# workspace, not the current one). Both pass `--ignore-working-copy`, as a
+# snapshot writes a jj operation that races any jj command run during
+# configure; `@` is then as of the last jj command.
 if("${LAKE_LEAN_GITHASH}" STREQUAL "")
   find_program(JJ_EXECUTABLE jj)
   if(JJ_EXECUTABLE)
     execute_process(
-      COMMAND "${JJ_EXECUTABLE}" git root
+      COMMAND "${JJ_EXECUTABLE}" --ignore-working-copy git root
       WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
       OUTPUT_VARIABLE _jj_git_dir
       OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -695,7 +697,7 @@ if("${LAKE_LEAN_GITHASH}" STREQUAL "")
       RESULT_VARIABLE _jj_git_root_result
     )
     execute_process(
-      COMMAND "${JJ_EXECUTABLE}" log -r @ --no-graph -T "commit_id"
+      COMMAND "${JJ_EXECUTABLE}" --ignore-working-copy log -r @ --no-graph -T "commit_id"
       WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
       OUTPUT_VARIABLE _jj_commit
       OUTPUT_STRIP_TRAILING_WHITESPACE


### PR DESCRIPTION
This PR makes the stage0 tree hash lookup for jj workspaces pass `--ignore-working-copy`, so configuring a build no longer writes a jj operation that races `jj` commands run at the same time.