### PR TITLE
feat: bundle the `con-leche` external checker with release toolchains

### DIFF
--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -253,7 +253,7 @@ jobs:
         if: matrix.release && !matrix.wasm
         run: |
           make -C build/$TARGET_STAGE leanchecker-paranoid -j$NPROC
-      - name: Build lean4lean
+      - name: Build lean4lean and con-leche
         if: matrix.release && !matrix.wasm
         run: |
           if ! command -v elan > /dev/null; then
@@ -264,7 +264,7 @@ jobs:
             export PATH="$PWD/build/elan/bin:$PATH"
           fi
           elan --version  # fails step if not found
-          make -C build/$TARGET_STAGE lean4lean
+          make -C build/$TARGET_STAGE lean4lean con-leche
       - name: Build nanoda
         if: matrix.release && !matrix.wasm
         run: |

--- a/LICENSES
+++ b/LICENSES
@@ -1372,8 +1372,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ==============================================================================
-leantar and lean4lean are by Mario Carneiro, nanoda is by Chris Bailey; all are
-distributed under the Apache 2.0 License:
+leantar and lean4lean are by Mario Carneiro, nanoda is by Chris Bailey,
+con-leche is by Lean FRO; all are distributed under the Apache 2.0 License:
 ==============================================================================
                                  Apache License
                            Version 2.0, January 2004

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1060,6 +1060,21 @@ if(NOT CMAKE_SYSTEM_NAME MATCHES "Emscripten")
       ${CMAKE_BINARY_DIR}/bin
   )
 
+  # Not in `ALL` as it's expensive; release CI builds it explicitly.
+  ExternalProject_Add(
+    con-leche
+    PREFIX con-leche
+    EXCLUDE_FROM_ALL ON
+    GIT_REPOSITORY https://github.com/leanprover/con-leche
+    GIT_TAG b46cb0e6138d975e657857526839a3c7d8a1df20
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND lake build con-leche
+    BUILD_IN_SOURCE ON
+    INSTALL_COMMAND
+      ${CMAKE_COMMAND} -E copy .lake/build/bin/con-leche${CMAKE_EXECUTABLE_SUFFIX}
+      ${CMAKE_BINARY_DIR}/bin
+  )
+
   # Not `ALL` as it's big; release CI builds it explicitly.
   if(USE_MIMALLOC)
     add_custom_target(

--- a/tests/pkg/con-leche/run_test.sh
+++ b/tests/pkg/con-leche/run_test.sh
@@ -1,0 +1,11 @@
+# `con-leche` is bundled into release toolchains only, where the build injects it into `bin/` before
+# installing. Skip rather than fail when absent, so an ordinary test run needs neither the binary nor
+# the network to build it.
+if ! command -v con-leche > /dev/null; then
+    echo "con-leche not built; skipping"
+    exit 0
+fi
+
+leanexport Init > "$TMP_DIR/export.ndjson"
+con-leche "$TMP_DIR/export.ndjson" | tee "$TMP_DIR/out"
+grep -qE '^con-leche: accepted [1-9][0-9]* declarations' "$TMP_DIR/out"


### PR DESCRIPTION
This PR bundles the `con-leche` external checker with release toolchains, so it can be used as an independent checker without a separate install.

Bundles https://github.com/leanprover/con-leche/commit/b46cb0e6138d975e657857526839a3c7d8a1df20

🤖 Generated with [Claude Code](https://claude.com/claude-code)
