### PR TITLE
perf: make high arity closures pass their arguments linearly if possible

### DIFF
--- a/script/apply.lean
+++ b/script/apply.lean
@@ -61,9 +61,18 @@ if (arity == fixed + {n}) \{
     let fs := mkFsArgs (j - n)
     let sep := if j = n then "" else ", "
     emit s!"    case {j}: \{ obj* r = FN{j}(f)({fs}{sep}{args}); lean_free_object(f); return r; }\n"
-  emit "    }
+  emit s!"    default:
+      lean_assert(arity > {max});
+      obj * as[{n}] = \{ {args} };
+      obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
+      for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+      for (unsigned i = 0; i < {n}; i++) args[fixed+i] = as[i];
+      obj * r = FNN(f)(args);
+      lean_free_object(f);
+      return r;
+    }
   }
-  switch (arity) {\n"
+  switch (arity) \{\n"
   for j in [n:max + 1] do
     let lean_incfs := mkIncFs (j - n)
     let fs := mkFsArgs (j - n)
@@ -83,10 +92,17 @@ if (arity == fixed + {n}) \{
   if n ≥ 2 then do
     emit  s!"  obj * as[{n}] = \{ {args} };
   obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-  for (unsigned i = 0; i < fixed; i++) \{ lean_inc(fx(i)); args[i] = fx(i); }
   for (unsigned i = 0; i < arity-fixed; i++) args[fixed+i] = as[i];
-  obj * new_f = curry(f, arity, args);
-  lean_dec_ref(f);
+  obj * new_f;
+  if (lean_is_exclusive(f)) \{
+    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+    new_f = curry(f, arity, args);
+    lean_free_object(f);
+  } else \{
+    for (unsigned i = 0; i < fixed; i++) \{ lean_inc(fx(i)); args[i] = fx(i); }
+    new_f = curry(f, arity, args);
+    lean_dec_ref(f);
+  }
   return lean_apply_n(new_f, {n}+fixed-arity, &as[arity-fixed]);\n"
   else emit s!"  lean_assert(fixed < arity);
   lean_unreachable();\n"
@@ -126,8 +142,14 @@ unsigned arity = lean_closure_arity(f);
 unsigned fixed = lean_closure_num_fixed(f);
 if (arity == fixed + n) \{
   obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-  for (unsigned i = 0; i < fixed; i++) \{ lean_inc(fx(i)); args[i] = fx(i); }
   for (unsigned i = 0; i < n; i++) args[fixed+i] = as[i];
+  if (lean_is_exclusive(f)) \{
+    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+    obj * r = FNN(f)(args);
+    lean_free_object(f);
+    return r;
+  }
+  for (unsigned i = 0; i < fixed; i++) \{ lean_inc(fx(i)); args[i] = fx(i); }
   obj * r = FNN(f)(args);
   lean_dec_ref(f);
   return r;
@@ -137,10 +159,16 @@ if (arity == fixed + n) \{
   if (arity > LEAN_CLOSURE_MAX_ARGS) \{
     // `f`'s code takes its arguments as an array
     obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-    for (unsigned i = 0; i < fixed; i++) \{ lean_inc(fx(i)); args[i] = fx(i); }
     for (unsigned i = 0; i < m; i++) args[fixed+i] = as[i];
-    new_f = FNN(f)(args);
-    lean_dec_ref(f);
+    if (lean_is_exclusive(f)) \{
+      for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+      new_f = FNN(f)(args);
+      lean_free_object(f);
+    } else \{
+      for (unsigned i = 0; i < fixed; i++) \{ lean_inc(fx(i)); args[i] = fx(i); }
+      new_f = FNN(f)(args);
+      lean_dec_ref(f);
+    }
   } else \{
     // `f`'s code takes `arity` separate arguments, so it must not be invoked through `FNN`;
     // `lean_apply_n` dispatches on `m` and consumes `f`.

--- a/script/apply.lean
+++ b/script/apply.lean
@@ -61,55 +61,51 @@ if (arity == fixed + {n}) \{
     let fs := mkFsArgs (j - n)
     let sep := if j = n then "" else ", "
     emit s!"    case {j}: \{ obj* r = FN{j}(f)({fs}{sep}{args}); lean_free_object(f); return r; }\n"
-  emit s!"    default:
-      lean_assert(arity > {max});
-      obj * as[{n}] = \{ {args} };
-      obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-      for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
-      for (unsigned i = 0; i < {n}; i++) args[fixed+i] = as[i];
-      obj * r = FNN(f)(args);
-      lean_free_object(f);
-      return r;
-    }
+  emit "    }
   }
-  switch (arity) \{\n"
+  switch (arity) {\n"
   for j in [n:max + 1] do
     let lean_incfs := mkIncFs (j - n)
     let fs := mkFsArgs (j - n)
     let sep := if j = n then "" else ", "
     emit  s!"  case {j}: \{ {lean_incfs}obj* r = FN{j}(f)({fs}{sep}{args}); lean_dec_ref(f); return r; }\n"
   emit s!"  default:
-    lean_assert(arity > {max});
     obj * as[{n}] = \{ {args} };
-    obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-    for (unsigned i = 0; i < fixed; i++) \{ lean_inc(fx(i)); args[i] = fx(i); }
-    for (unsigned i = 0; i < {n}; i++) args[fixed+i] = as[i];
-    obj * r = FNN(f)(args);
-    lean_dec_ref(f);
-    return r;
+    return apply_packed(f, as, {n});
   }
 } else if (arity < fixed + {n}) \{\n"
   if n ≥ 2 then do
     emit  s!"  obj * as[{n}] = \{ {args} };
-  obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-  for (unsigned i = 0; i < arity-fixed; i++) args[fixed+i] = as[i];
-  obj * new_f;
-  if (lean_is_exclusive(f)) \{
-    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
-    new_f = curry(f, arity, args);
-    lean_free_object(f);
-  } else \{
-    for (unsigned i = 0; i < fixed; i++) \{ lean_inc(fx(i)); args[i] = fx(i); }
-    new_f = curry(f, arity, args);
-    lean_dec_ref(f);
-  }
-  return lean_apply_n(new_f, {n}+fixed-arity, &as[arity-fixed]);\n"
+  return apply_oversat(f, as, {n});\n"
   else emit s!"  lean_assert(fixed < arity);
   lean_unreachable();\n"
   emit s!"} else \{
   return fix_args(f, \{{args}});
 }
 }\n"
+
+def mkApplyPacked : M Unit := emit "
+__attribute__((noinline))
+static obj* apply_packed(obj* f, obj** as, unsigned n) {
+  unsigned arity = lean_closure_arity(f);
+  unsigned fixed = lean_closure_num_fixed(f);
+  lean_assert(arity == fixed + n);
+  lean_assert(arity > LEAN_CLOSURE_MAX_ARGS);
+  obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
+  for (unsigned i = 0; i < n; i++) args[fixed+i] = as[i];
+  obj* ret;
+  if (lean_is_exclusive(f)) {
+    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+    ret = FNN(f)(args);
+    lean_free_object(f);
+  } else {
+    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
+    ret = FNN(f)(args);
+    lean_dec_ref(f);
+  }
+  return ret;
+}
+"
 
 def mkCurry (max : Nat) : M Unit := do
   emit "obj* curry(void* f, unsigned n, obj** as) {
@@ -122,6 +118,28 @@ case 0: lean_unreachable();\n"
 }
 }
 static obj* curry(obj* f, unsigned n, obj** as) { return curry(lean_closure_fun(f), n, as); }\n"
+
+def mkApplyOversat : M Unit := emit "
+__attribute__((noinline))
+static obj* apply_oversat(obj* f, obj** as, unsigned n) {
+  unsigned arity = lean_closure_arity(f);
+  unsigned fixed = lean_closure_num_fixed(f);
+  lean_assert(fixed < arity && arity < fixed + n);
+  obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
+  for (unsigned i = 0; i < arity-fixed; i++) args[fixed+i] = as[i];
+  obj* new_f;
+  if (lean_is_exclusive(f)) {
+    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+    new_f = curry(f, arity, args);
+    lean_free_object(f);
+  } else {
+    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
+    new_f = curry(f, arity, args);
+    lean_dec_ref(f);
+  }
+  return lean_apply_n(new_f, n+fixed-arity, &as[arity-fixed]);
+}
+"
 
 def mkApplyN (max : Nat) : M Unit := do
   emit "extern \"C\" LEAN_EXPORT obj* lean_apply_n(obj* f, unsigned n, obj** as) {
@@ -141,34 +159,13 @@ if (lean_is_scalar(f)) \{ for (unsigned i = 0; i < n; i++) \{ lean_dec(as[i]); }
 unsigned arity = lean_closure_arity(f);
 unsigned fixed = lean_closure_num_fixed(f);
 if (arity == fixed + n) \{
-  obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-  for (unsigned i = 0; i < n; i++) args[fixed+i] = as[i];
-  if (lean_is_exclusive(f)) \{
-    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
-    obj * r = FNN(f)(args);
-    lean_free_object(f);
-    return r;
-  }
-  for (unsigned i = 0; i < fixed; i++) \{ lean_inc(fx(i)); args[i] = fx(i); }
-  obj * r = FNN(f)(args);
-  lean_dec_ref(f);
-  return r;
+  return apply_packed(f, as, n);
 } else if (arity < fixed + n) \{
   unsigned m = arity - fixed;
   obj * new_f;
   if (arity > LEAN_CLOSURE_MAX_ARGS) \{
     // `f`'s code takes its arguments as an array
-    obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-    for (unsigned i = 0; i < m; i++) args[fixed+i] = as[i];
-    if (lean_is_exclusive(f)) \{
-      for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
-      new_f = FNN(f)(args);
-      lean_free_object(f);
-    } else \{
-      for (unsigned i = 0; i < fixed; i++) \{ lean_inc(fx(i)); args[i] = fx(i); }
-      new_f = FNN(f)(args);
-      lean_dec_ref(f);
-    }
+    new_f = apply_packed(f, as, m);
   } else \{
     // `f`'s code takes `arity` separate arguments, so it must not be invoked through `FNN`;
     // `lean_apply_n` dispatches on `m` and consumes `f`.
@@ -232,8 +229,10 @@ namespace lean {
   for i in [0:max] do mkTypedefFn (i+1)
   emit "typedef obj* (*fnn)(obj**); // NOLINT
 #define FNN(f) reinterpret_cast<fnn>(lean_closure_fun(f))\n"
+  mkApplyPacked
   mkCurry max
   emit "extern \"C\" obj* lean_apply_n(obj*, unsigned, obj**);\n"
+  mkApplyOversat
   for i in [0:max] do mkApplyI (i+1) max
   mkApplyM max
   mkApplyN max

--- a/src/runtime/apply.cpp
+++ b/src/runtime/apply.cpp
@@ -121,6 +121,15 @@ if (arity == fixed + 1) {
     case 14: { obj* r = FN14(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), fx(10), fx(11), fx(12), a1); lean_free_object(f); return r; }
     case 15: { obj* r = FN15(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), fx(10), fx(11), fx(12), fx(13), a1); lean_free_object(f); return r; }
     case 16: { obj* r = FN16(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), fx(10), fx(11), fx(12), fx(13), fx(14), a1); lean_free_object(f); return r; }
+    default:
+      lean_assert(arity > 16);
+      obj * as[1] = { a1 };
+      obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
+      for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+      for (unsigned i = 0; i < 1; i++) args[fixed+i] = as[i];
+      obj * r = FNN(f)(args);
+      lean_free_object(f);
+      return r;
     }
   }
   switch (arity) {
@@ -179,6 +188,15 @@ if (arity == fixed + 2) {
     case 14: { obj* r = FN14(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), fx(10), fx(11), a1, a2); lean_free_object(f); return r; }
     case 15: { obj* r = FN15(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), fx(10), fx(11), fx(12), a1, a2); lean_free_object(f); return r; }
     case 16: { obj* r = FN16(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), fx(10), fx(11), fx(12), fx(13), a1, a2); lean_free_object(f); return r; }
+    default:
+      lean_assert(arity > 16);
+      obj * as[2] = { a1, a2 };
+      obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
+      for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+      for (unsigned i = 0; i < 2; i++) args[fixed+i] = as[i];
+      obj * r = FNN(f)(args);
+      lean_free_object(f);
+      return r;
     }
   }
   switch (arity) {
@@ -210,10 +228,17 @@ if (arity == fixed + 2) {
 } else if (arity < fixed + 2) {
   obj * as[2] = { a1, a2 };
   obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-  for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
   for (unsigned i = 0; i < arity-fixed; i++) args[fixed+i] = as[i];
-  obj * new_f = curry(f, arity, args);
-  lean_dec_ref(f);
+  obj * new_f;
+  if (lean_is_exclusive(f)) {
+    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+    new_f = curry(f, arity, args);
+    lean_free_object(f);
+  } else {
+    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
+    new_f = curry(f, arity, args);
+    lean_dec_ref(f);
+  }
   return lean_apply_n(new_f, 2+fixed-arity, &as[arity-fixed]);
 } else {
   return fix_args(f, {a1, a2});
@@ -240,6 +265,15 @@ if (arity == fixed + 3) {
     case 14: { obj* r = FN14(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), fx(10), a1, a2, a3); lean_free_object(f); return r; }
     case 15: { obj* r = FN15(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), fx(10), fx(11), a1, a2, a3); lean_free_object(f); return r; }
     case 16: { obj* r = FN16(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), fx(10), fx(11), fx(12), a1, a2, a3); lean_free_object(f); return r; }
+    default:
+      lean_assert(arity > 16);
+      obj * as[3] = { a1, a2, a3 };
+      obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
+      for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+      for (unsigned i = 0; i < 3; i++) args[fixed+i] = as[i];
+      obj * r = FNN(f)(args);
+      lean_free_object(f);
+      return r;
     }
   }
   switch (arity) {
@@ -270,10 +304,17 @@ if (arity == fixed + 3) {
 } else if (arity < fixed + 3) {
   obj * as[3] = { a1, a2, a3 };
   obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-  for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
   for (unsigned i = 0; i < arity-fixed; i++) args[fixed+i] = as[i];
-  obj * new_f = curry(f, arity, args);
-  lean_dec_ref(f);
+  obj * new_f;
+  if (lean_is_exclusive(f)) {
+    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+    new_f = curry(f, arity, args);
+    lean_free_object(f);
+  } else {
+    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
+    new_f = curry(f, arity, args);
+    lean_dec_ref(f);
+  }
   return lean_apply_n(new_f, 3+fixed-arity, &as[arity-fixed]);
 } else {
   return fix_args(f, {a1, a2, a3});
@@ -299,6 +340,15 @@ if (arity == fixed + 4) {
     case 14: { obj* r = FN14(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), a1, a2, a3, a4); lean_free_object(f); return r; }
     case 15: { obj* r = FN15(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), fx(10), a1, a2, a3, a4); lean_free_object(f); return r; }
     case 16: { obj* r = FN16(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), fx(10), fx(11), a1, a2, a3, a4); lean_free_object(f); return r; }
+    default:
+      lean_assert(arity > 16);
+      obj * as[4] = { a1, a2, a3, a4 };
+      obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
+      for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+      for (unsigned i = 0; i < 4; i++) args[fixed+i] = as[i];
+      obj * r = FNN(f)(args);
+      lean_free_object(f);
+      return r;
     }
   }
   switch (arity) {
@@ -328,10 +378,17 @@ if (arity == fixed + 4) {
 } else if (arity < fixed + 4) {
   obj * as[4] = { a1, a2, a3, a4 };
   obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-  for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
   for (unsigned i = 0; i < arity-fixed; i++) args[fixed+i] = as[i];
-  obj * new_f = curry(f, arity, args);
-  lean_dec_ref(f);
+  obj * new_f;
+  if (lean_is_exclusive(f)) {
+    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+    new_f = curry(f, arity, args);
+    lean_free_object(f);
+  } else {
+    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
+    new_f = curry(f, arity, args);
+    lean_dec_ref(f);
+  }
   return lean_apply_n(new_f, 4+fixed-arity, &as[arity-fixed]);
 } else {
   return fix_args(f, {a1, a2, a3, a4});
@@ -356,6 +413,15 @@ if (arity == fixed + 5) {
     case 14: { obj* r = FN14(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), a1, a2, a3, a4, a5); lean_free_object(f); return r; }
     case 15: { obj* r = FN15(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), a1, a2, a3, a4, a5); lean_free_object(f); return r; }
     case 16: { obj* r = FN16(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), fx(10), a1, a2, a3, a4, a5); lean_free_object(f); return r; }
+    default:
+      lean_assert(arity > 16);
+      obj * as[5] = { a1, a2, a3, a4, a5 };
+      obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
+      for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+      for (unsigned i = 0; i < 5; i++) args[fixed+i] = as[i];
+      obj * r = FNN(f)(args);
+      lean_free_object(f);
+      return r;
     }
   }
   switch (arity) {
@@ -384,10 +450,17 @@ if (arity == fixed + 5) {
 } else if (arity < fixed + 5) {
   obj * as[5] = { a1, a2, a3, a4, a5 };
   obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-  for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
   for (unsigned i = 0; i < arity-fixed; i++) args[fixed+i] = as[i];
-  obj * new_f = curry(f, arity, args);
-  lean_dec_ref(f);
+  obj * new_f;
+  if (lean_is_exclusive(f)) {
+    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+    new_f = curry(f, arity, args);
+    lean_free_object(f);
+  } else {
+    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
+    new_f = curry(f, arity, args);
+    lean_dec_ref(f);
+  }
   return lean_apply_n(new_f, 5+fixed-arity, &as[arity-fixed]);
 } else {
   return fix_args(f, {a1, a2, a3, a4, a5});
@@ -411,6 +484,15 @@ if (arity == fixed + 6) {
     case 14: { obj* r = FN14(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), a1, a2, a3, a4, a5, a6); lean_free_object(f); return r; }
     case 15: { obj* r = FN15(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), a1, a2, a3, a4, a5, a6); lean_free_object(f); return r; }
     case 16: { obj* r = FN16(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), a1, a2, a3, a4, a5, a6); lean_free_object(f); return r; }
+    default:
+      lean_assert(arity > 16);
+      obj * as[6] = { a1, a2, a3, a4, a5, a6 };
+      obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
+      for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+      for (unsigned i = 0; i < 6; i++) args[fixed+i] = as[i];
+      obj * r = FNN(f)(args);
+      lean_free_object(f);
+      return r;
     }
   }
   switch (arity) {
@@ -438,10 +520,17 @@ if (arity == fixed + 6) {
 } else if (arity < fixed + 6) {
   obj * as[6] = { a1, a2, a3, a4, a5, a6 };
   obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-  for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
   for (unsigned i = 0; i < arity-fixed; i++) args[fixed+i] = as[i];
-  obj * new_f = curry(f, arity, args);
-  lean_dec_ref(f);
+  obj * new_f;
+  if (lean_is_exclusive(f)) {
+    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+    new_f = curry(f, arity, args);
+    lean_free_object(f);
+  } else {
+    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
+    new_f = curry(f, arity, args);
+    lean_dec_ref(f);
+  }
   return lean_apply_n(new_f, 6+fixed-arity, &as[arity-fixed]);
 } else {
   return fix_args(f, {a1, a2, a3, a4, a5, a6});
@@ -464,6 +553,15 @@ if (arity == fixed + 7) {
     case 14: { obj* r = FN14(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), a1, a2, a3, a4, a5, a6, a7); lean_free_object(f); return r; }
     case 15: { obj* r = FN15(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), a1, a2, a3, a4, a5, a6, a7); lean_free_object(f); return r; }
     case 16: { obj* r = FN16(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), a1, a2, a3, a4, a5, a6, a7); lean_free_object(f); return r; }
+    default:
+      lean_assert(arity > 16);
+      obj * as[7] = { a1, a2, a3, a4, a5, a6, a7 };
+      obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
+      for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+      for (unsigned i = 0; i < 7; i++) args[fixed+i] = as[i];
+      obj * r = FNN(f)(args);
+      lean_free_object(f);
+      return r;
     }
   }
   switch (arity) {
@@ -490,10 +588,17 @@ if (arity == fixed + 7) {
 } else if (arity < fixed + 7) {
   obj * as[7] = { a1, a2, a3, a4, a5, a6, a7 };
   obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-  for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
   for (unsigned i = 0; i < arity-fixed; i++) args[fixed+i] = as[i];
-  obj * new_f = curry(f, arity, args);
-  lean_dec_ref(f);
+  obj * new_f;
+  if (lean_is_exclusive(f)) {
+    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+    new_f = curry(f, arity, args);
+    lean_free_object(f);
+  } else {
+    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
+    new_f = curry(f, arity, args);
+    lean_dec_ref(f);
+  }
   return lean_apply_n(new_f, 7+fixed-arity, &as[arity-fixed]);
 } else {
   return fix_args(f, {a1, a2, a3, a4, a5, a6, a7});
@@ -515,6 +620,15 @@ if (arity == fixed + 8) {
     case 14: { obj* r = FN14(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), a1, a2, a3, a4, a5, a6, a7, a8); lean_free_object(f); return r; }
     case 15: { obj* r = FN15(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), a1, a2, a3, a4, a5, a6, a7, a8); lean_free_object(f); return r; }
     case 16: { obj* r = FN16(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), a1, a2, a3, a4, a5, a6, a7, a8); lean_free_object(f); return r; }
+    default:
+      lean_assert(arity > 16);
+      obj * as[8] = { a1, a2, a3, a4, a5, a6, a7, a8 };
+      obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
+      for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+      for (unsigned i = 0; i < 8; i++) args[fixed+i] = as[i];
+      obj * r = FNN(f)(args);
+      lean_free_object(f);
+      return r;
     }
   }
   switch (arity) {
@@ -540,10 +654,17 @@ if (arity == fixed + 8) {
 } else if (arity < fixed + 8) {
   obj * as[8] = { a1, a2, a3, a4, a5, a6, a7, a8 };
   obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-  for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
   for (unsigned i = 0; i < arity-fixed; i++) args[fixed+i] = as[i];
-  obj * new_f = curry(f, arity, args);
-  lean_dec_ref(f);
+  obj * new_f;
+  if (lean_is_exclusive(f)) {
+    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+    new_f = curry(f, arity, args);
+    lean_free_object(f);
+  } else {
+    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
+    new_f = curry(f, arity, args);
+    lean_dec_ref(f);
+  }
   return lean_apply_n(new_f, 8+fixed-arity, &as[arity-fixed]);
 } else {
   return fix_args(f, {a1, a2, a3, a4, a5, a6, a7, a8});
@@ -564,6 +685,15 @@ if (arity == fixed + 9) {
     case 14: { obj* r = FN14(f)(fx(0), fx(1), fx(2), fx(3), fx(4), a1, a2, a3, a4, a5, a6, a7, a8, a9); lean_free_object(f); return r; }
     case 15: { obj* r = FN15(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), a1, a2, a3, a4, a5, a6, a7, a8, a9); lean_free_object(f); return r; }
     case 16: { obj* r = FN16(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), a1, a2, a3, a4, a5, a6, a7, a8, a9); lean_free_object(f); return r; }
+    default:
+      lean_assert(arity > 16);
+      obj * as[9] = { a1, a2, a3, a4, a5, a6, a7, a8, a9 };
+      obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
+      for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+      for (unsigned i = 0; i < 9; i++) args[fixed+i] = as[i];
+      obj * r = FNN(f)(args);
+      lean_free_object(f);
+      return r;
     }
   }
   switch (arity) {
@@ -588,10 +718,17 @@ if (arity == fixed + 9) {
 } else if (arity < fixed + 9) {
   obj * as[9] = { a1, a2, a3, a4, a5, a6, a7, a8, a9 };
   obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-  for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
   for (unsigned i = 0; i < arity-fixed; i++) args[fixed+i] = as[i];
-  obj * new_f = curry(f, arity, args);
-  lean_dec_ref(f);
+  obj * new_f;
+  if (lean_is_exclusive(f)) {
+    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+    new_f = curry(f, arity, args);
+    lean_free_object(f);
+  } else {
+    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
+    new_f = curry(f, arity, args);
+    lean_dec_ref(f);
+  }
   return lean_apply_n(new_f, 9+fixed-arity, &as[arity-fixed]);
 } else {
   return fix_args(f, {a1, a2, a3, a4, a5, a6, a7, a8, a9});
@@ -611,6 +748,15 @@ if (arity == fixed + 10) {
     case 14: { obj* r = FN14(f)(fx(0), fx(1), fx(2), fx(3), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10); lean_free_object(f); return r; }
     case 15: { obj* r = FN15(f)(fx(0), fx(1), fx(2), fx(3), fx(4), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10); lean_free_object(f); return r; }
     case 16: { obj* r = FN16(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10); lean_free_object(f); return r; }
+    default:
+      lean_assert(arity > 16);
+      obj * as[10] = { a1, a2, a3, a4, a5, a6, a7, a8, a9, a10 };
+      obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
+      for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+      for (unsigned i = 0; i < 10; i++) args[fixed+i] = as[i];
+      obj * r = FNN(f)(args);
+      lean_free_object(f);
+      return r;
     }
   }
   switch (arity) {
@@ -634,10 +780,17 @@ if (arity == fixed + 10) {
 } else if (arity < fixed + 10) {
   obj * as[10] = { a1, a2, a3, a4, a5, a6, a7, a8, a9, a10 };
   obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-  for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
   for (unsigned i = 0; i < arity-fixed; i++) args[fixed+i] = as[i];
-  obj * new_f = curry(f, arity, args);
-  lean_dec_ref(f);
+  obj * new_f;
+  if (lean_is_exclusive(f)) {
+    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+    new_f = curry(f, arity, args);
+    lean_free_object(f);
+  } else {
+    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
+    new_f = curry(f, arity, args);
+    lean_dec_ref(f);
+  }
   return lean_apply_n(new_f, 10+fixed-arity, &as[arity-fixed]);
 } else {
   return fix_args(f, {a1, a2, a3, a4, a5, a6, a7, a8, a9, a10});
@@ -656,6 +809,15 @@ if (arity == fixed + 11) {
     case 14: { obj* r = FN14(f)(fx(0), fx(1), fx(2), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11); lean_free_object(f); return r; }
     case 15: { obj* r = FN15(f)(fx(0), fx(1), fx(2), fx(3), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11); lean_free_object(f); return r; }
     case 16: { obj* r = FN16(f)(fx(0), fx(1), fx(2), fx(3), fx(4), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11); lean_free_object(f); return r; }
+    default:
+      lean_assert(arity > 16);
+      obj * as[11] = { a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11 };
+      obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
+      for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+      for (unsigned i = 0; i < 11; i++) args[fixed+i] = as[i];
+      obj * r = FNN(f)(args);
+      lean_free_object(f);
+      return r;
     }
   }
   switch (arity) {
@@ -678,10 +840,17 @@ if (arity == fixed + 11) {
 } else if (arity < fixed + 11) {
   obj * as[11] = { a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11 };
   obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-  for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
   for (unsigned i = 0; i < arity-fixed; i++) args[fixed+i] = as[i];
-  obj * new_f = curry(f, arity, args);
-  lean_dec_ref(f);
+  obj * new_f;
+  if (lean_is_exclusive(f)) {
+    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+    new_f = curry(f, arity, args);
+    lean_free_object(f);
+  } else {
+    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
+    new_f = curry(f, arity, args);
+    lean_dec_ref(f);
+  }
   return lean_apply_n(new_f, 11+fixed-arity, &as[arity-fixed]);
 } else {
   return fix_args(f, {a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11});
@@ -699,6 +868,15 @@ if (arity == fixed + 12) {
     case 14: { obj* r = FN14(f)(fx(0), fx(1), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12); lean_free_object(f); return r; }
     case 15: { obj* r = FN15(f)(fx(0), fx(1), fx(2), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12); lean_free_object(f); return r; }
     case 16: { obj* r = FN16(f)(fx(0), fx(1), fx(2), fx(3), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12); lean_free_object(f); return r; }
+    default:
+      lean_assert(arity > 16);
+      obj * as[12] = { a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12 };
+      obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
+      for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+      for (unsigned i = 0; i < 12; i++) args[fixed+i] = as[i];
+      obj * r = FNN(f)(args);
+      lean_free_object(f);
+      return r;
     }
   }
   switch (arity) {
@@ -720,10 +898,17 @@ if (arity == fixed + 12) {
 } else if (arity < fixed + 12) {
   obj * as[12] = { a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12 };
   obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-  for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
   for (unsigned i = 0; i < arity-fixed; i++) args[fixed+i] = as[i];
-  obj * new_f = curry(f, arity, args);
-  lean_dec_ref(f);
+  obj * new_f;
+  if (lean_is_exclusive(f)) {
+    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+    new_f = curry(f, arity, args);
+    lean_free_object(f);
+  } else {
+    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
+    new_f = curry(f, arity, args);
+    lean_dec_ref(f);
+  }
   return lean_apply_n(new_f, 12+fixed-arity, &as[arity-fixed]);
 } else {
   return fix_args(f, {a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12});
@@ -740,6 +925,15 @@ if (arity == fixed + 13) {
     case 14: { obj* r = FN14(f)(fx(0), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13); lean_free_object(f); return r; }
     case 15: { obj* r = FN15(f)(fx(0), fx(1), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13); lean_free_object(f); return r; }
     case 16: { obj* r = FN16(f)(fx(0), fx(1), fx(2), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13); lean_free_object(f); return r; }
+    default:
+      lean_assert(arity > 16);
+      obj * as[13] = { a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13 };
+      obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
+      for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+      for (unsigned i = 0; i < 13; i++) args[fixed+i] = as[i];
+      obj * r = FNN(f)(args);
+      lean_free_object(f);
+      return r;
     }
   }
   switch (arity) {
@@ -760,10 +954,17 @@ if (arity == fixed + 13) {
 } else if (arity < fixed + 13) {
   obj * as[13] = { a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13 };
   obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-  for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
   for (unsigned i = 0; i < arity-fixed; i++) args[fixed+i] = as[i];
-  obj * new_f = curry(f, arity, args);
-  lean_dec_ref(f);
+  obj * new_f;
+  if (lean_is_exclusive(f)) {
+    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+    new_f = curry(f, arity, args);
+    lean_free_object(f);
+  } else {
+    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
+    new_f = curry(f, arity, args);
+    lean_dec_ref(f);
+  }
   return lean_apply_n(new_f, 13+fixed-arity, &as[arity-fixed]);
 } else {
   return fix_args(f, {a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13});
@@ -779,6 +980,15 @@ if (arity == fixed + 14) {
     case 14: { obj* r = FN14(f)(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14); lean_free_object(f); return r; }
     case 15: { obj* r = FN15(f)(fx(0), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14); lean_free_object(f); return r; }
     case 16: { obj* r = FN16(f)(fx(0), fx(1), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14); lean_free_object(f); return r; }
+    default:
+      lean_assert(arity > 16);
+      obj * as[14] = { a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14 };
+      obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
+      for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+      for (unsigned i = 0; i < 14; i++) args[fixed+i] = as[i];
+      obj * r = FNN(f)(args);
+      lean_free_object(f);
+      return r;
     }
   }
   switch (arity) {
@@ -798,10 +1008,17 @@ if (arity == fixed + 14) {
 } else if (arity < fixed + 14) {
   obj * as[14] = { a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14 };
   obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-  for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
   for (unsigned i = 0; i < arity-fixed; i++) args[fixed+i] = as[i];
-  obj * new_f = curry(f, arity, args);
-  lean_dec_ref(f);
+  obj * new_f;
+  if (lean_is_exclusive(f)) {
+    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+    new_f = curry(f, arity, args);
+    lean_free_object(f);
+  } else {
+    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
+    new_f = curry(f, arity, args);
+    lean_dec_ref(f);
+  }
   return lean_apply_n(new_f, 14+fixed-arity, &as[arity-fixed]);
 } else {
   return fix_args(f, {a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14});
@@ -816,6 +1033,15 @@ if (arity == fixed + 15) {
     switch (arity) {
     case 15: { obj* r = FN15(f)(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15); lean_free_object(f); return r; }
     case 16: { obj* r = FN16(f)(fx(0), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15); lean_free_object(f); return r; }
+    default:
+      lean_assert(arity > 16);
+      obj * as[15] = { a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15 };
+      obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
+      for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+      for (unsigned i = 0; i < 15; i++) args[fixed+i] = as[i];
+      obj * r = FNN(f)(args);
+      lean_free_object(f);
+      return r;
     }
   }
   switch (arity) {
@@ -834,10 +1060,17 @@ if (arity == fixed + 15) {
 } else if (arity < fixed + 15) {
   obj * as[15] = { a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15 };
   obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-  for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
   for (unsigned i = 0; i < arity-fixed; i++) args[fixed+i] = as[i];
-  obj * new_f = curry(f, arity, args);
-  lean_dec_ref(f);
+  obj * new_f;
+  if (lean_is_exclusive(f)) {
+    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+    new_f = curry(f, arity, args);
+    lean_free_object(f);
+  } else {
+    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
+    new_f = curry(f, arity, args);
+    lean_dec_ref(f);
+  }
   return lean_apply_n(new_f, 15+fixed-arity, &as[arity-fixed]);
 } else {
   return fix_args(f, {a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15});
@@ -851,6 +1084,15 @@ if (arity == fixed + 16) {
   if (lean_is_exclusive(f)) {
     switch (arity) {
     case 16: { obj* r = FN16(f)(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16); lean_free_object(f); return r; }
+    default:
+      lean_assert(arity > 16);
+      obj * as[16] = { a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16 };
+      obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
+      for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+      for (unsigned i = 0; i < 16; i++) args[fixed+i] = as[i];
+      obj * r = FNN(f)(args);
+      lean_free_object(f);
+      return r;
     }
   }
   switch (arity) {
@@ -868,10 +1110,17 @@ if (arity == fixed + 16) {
 } else if (arity < fixed + 16) {
   obj * as[16] = { a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16 };
   obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-  for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
   for (unsigned i = 0; i < arity-fixed; i++) args[fixed+i] = as[i];
-  obj * new_f = curry(f, arity, args);
-  lean_dec_ref(f);
+  obj * new_f;
+  if (lean_is_exclusive(f)) {
+    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+    new_f = curry(f, arity, args);
+    lean_free_object(f);
+  } else {
+    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
+    new_f = curry(f, arity, args);
+    lean_dec_ref(f);
+  }
   return lean_apply_n(new_f, 16+fixed-arity, &as[arity-fixed]);
 } else {
   return fix_args(f, {a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16});
@@ -884,8 +1133,14 @@ unsigned arity = lean_closure_arity(f);
 unsigned fixed = lean_closure_num_fixed(f);
 if (arity == fixed + n) {
   obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-  for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
   for (unsigned i = 0; i < n; i++) args[fixed+i] = as[i];
+  if (lean_is_exclusive(f)) {
+    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+    obj * r = FNN(f)(args);
+    lean_free_object(f);
+    return r;
+  }
+  for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
   obj * r = FNN(f)(args);
   lean_dec_ref(f);
   return r;
@@ -895,10 +1150,16 @@ if (arity == fixed + n) {
   if (arity > LEAN_CLOSURE_MAX_ARGS) {
     // `f`'s code takes its arguments as an array
     obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
     for (unsigned i = 0; i < m; i++) args[fixed+i] = as[i];
-    new_f = FNN(f)(args);
-    lean_dec_ref(f);
+    if (lean_is_exclusive(f)) {
+      for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+      new_f = FNN(f)(args);
+      lean_free_object(f);
+    } else {
+      for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
+      new_f = FNN(f)(args);
+      lean_dec_ref(f);
+    }
   } else {
     // `f`'s code takes `arity` separate arguments, so it must not be invoked through `FNN`;
     // `lean_apply_n` dispatches on `m` and consumes `f`.

--- a/src/runtime/apply.cpp
+++ b/src/runtime/apply.cpp
@@ -74,6 +74,27 @@ typedef obj* (*fn16)(obj*, obj*, obj*, obj*, obj*, obj*, obj*, obj*, obj*, obj*,
 #define FN16(f) reinterpret_cast<fn16>(lean_closure_fun(f))
 typedef obj* (*fnn)(obj**); // NOLINT
 #define FNN(f) reinterpret_cast<fnn>(lean_closure_fun(f))
+
+__attribute__((noinline))
+static obj* apply_packed(obj* f, obj** as, unsigned n) {
+  unsigned arity = lean_closure_arity(f);
+  unsigned fixed = lean_closure_num_fixed(f);
+  lean_assert(arity == fixed + n);
+  lean_assert(arity > LEAN_CLOSURE_MAX_ARGS);
+  obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
+  for (unsigned i = 0; i < n; i++) args[fixed+i] = as[i];
+  obj* ret;
+  if (lean_is_exclusive(f)) {
+    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+    ret = FNN(f)(args);
+    lean_free_object(f);
+  } else {
+    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
+    ret = FNN(f)(args);
+    lean_dec_ref(f);
+  }
+  return ret;
+}
 obj* curry(void* f, unsigned n, obj** as) {
 switch (n) {
 case 0: lean_unreachable();
@@ -98,6 +119,26 @@ default: return reinterpret_cast<fnn>(f)(as);
 }
 static obj* curry(obj* f, unsigned n, obj** as) { return curry(lean_closure_fun(f), n, as); }
 extern "C" obj* lean_apply_n(obj*, unsigned, obj**);
+
+__attribute__((noinline))
+static obj* apply_oversat(obj* f, obj** as, unsigned n) {
+  unsigned arity = lean_closure_arity(f);
+  unsigned fixed = lean_closure_num_fixed(f);
+  lean_assert(fixed < arity && arity < fixed + n);
+  obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
+  for (unsigned i = 0; i < arity-fixed; i++) args[fixed+i] = as[i];
+  obj* new_f;
+  if (lean_is_exclusive(f)) {
+    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
+    new_f = curry(f, arity, args);
+    lean_free_object(f);
+  } else {
+    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
+    new_f = curry(f, arity, args);
+    lean_dec_ref(f);
+  }
+  return lean_apply_n(new_f, n+fixed-arity, &as[arity-fixed]);
+}
 extern "C" LEAN_EXPORT obj* lean_apply_1(obj* f, obj* a1) {
 if (lean_is_scalar(f)) { lean_dec(a1); return f; } // f is an erased proof
 unsigned arity = lean_closure_arity(f);
@@ -121,15 +162,6 @@ if (arity == fixed + 1) {
     case 14: { obj* r = FN14(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), fx(10), fx(11), fx(12), a1); lean_free_object(f); return r; }
     case 15: { obj* r = FN15(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), fx(10), fx(11), fx(12), fx(13), a1); lean_free_object(f); return r; }
     case 16: { obj* r = FN16(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), fx(10), fx(11), fx(12), fx(13), fx(14), a1); lean_free_object(f); return r; }
-    default:
-      lean_assert(arity > 16);
-      obj * as[1] = { a1 };
-      obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-      for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
-      for (unsigned i = 0; i < 1; i++) args[fixed+i] = as[i];
-      obj * r = FNN(f)(args);
-      lean_free_object(f);
-      return r;
     }
   }
   switch (arity) {
@@ -150,14 +182,8 @@ if (arity == fixed + 1) {
   case 15: { lean_inc(fx(0)); lean_inc(fx(1)); lean_inc(fx(2)); lean_inc(fx(3)); lean_inc(fx(4)); lean_inc(fx(5)); lean_inc(fx(6)); lean_inc(fx(7)); lean_inc(fx(8)); lean_inc(fx(9)); lean_inc(fx(10)); lean_inc(fx(11)); lean_inc(fx(12)); lean_inc(fx(13)); obj* r = FN15(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), fx(10), fx(11), fx(12), fx(13), a1); lean_dec_ref(f); return r; }
   case 16: { lean_inc(fx(0)); lean_inc(fx(1)); lean_inc(fx(2)); lean_inc(fx(3)); lean_inc(fx(4)); lean_inc(fx(5)); lean_inc(fx(6)); lean_inc(fx(7)); lean_inc(fx(8)); lean_inc(fx(9)); lean_inc(fx(10)); lean_inc(fx(11)); lean_inc(fx(12)); lean_inc(fx(13)); lean_inc(fx(14)); obj* r = FN16(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), fx(10), fx(11), fx(12), fx(13), fx(14), a1); lean_dec_ref(f); return r; }
   default:
-    lean_assert(arity > 16);
     obj * as[1] = { a1 };
-    obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
-    for (unsigned i = 0; i < 1; i++) args[fixed+i] = as[i];
-    obj * r = FNN(f)(args);
-    lean_dec_ref(f);
-    return r;
+    return apply_packed(f, as, 1);
   }
 } else if (arity < fixed + 1) {
   lean_assert(fixed < arity);
@@ -188,15 +214,6 @@ if (arity == fixed + 2) {
     case 14: { obj* r = FN14(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), fx(10), fx(11), a1, a2); lean_free_object(f); return r; }
     case 15: { obj* r = FN15(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), fx(10), fx(11), fx(12), a1, a2); lean_free_object(f); return r; }
     case 16: { obj* r = FN16(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), fx(10), fx(11), fx(12), fx(13), a1, a2); lean_free_object(f); return r; }
-    default:
-      lean_assert(arity > 16);
-      obj * as[2] = { a1, a2 };
-      obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-      for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
-      for (unsigned i = 0; i < 2; i++) args[fixed+i] = as[i];
-      obj * r = FNN(f)(args);
-      lean_free_object(f);
-      return r;
     }
   }
   switch (arity) {
@@ -216,30 +233,12 @@ if (arity == fixed + 2) {
   case 15: { lean_inc(fx(0)); lean_inc(fx(1)); lean_inc(fx(2)); lean_inc(fx(3)); lean_inc(fx(4)); lean_inc(fx(5)); lean_inc(fx(6)); lean_inc(fx(7)); lean_inc(fx(8)); lean_inc(fx(9)); lean_inc(fx(10)); lean_inc(fx(11)); lean_inc(fx(12)); obj* r = FN15(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), fx(10), fx(11), fx(12), a1, a2); lean_dec_ref(f); return r; }
   case 16: { lean_inc(fx(0)); lean_inc(fx(1)); lean_inc(fx(2)); lean_inc(fx(3)); lean_inc(fx(4)); lean_inc(fx(5)); lean_inc(fx(6)); lean_inc(fx(7)); lean_inc(fx(8)); lean_inc(fx(9)); lean_inc(fx(10)); lean_inc(fx(11)); lean_inc(fx(12)); lean_inc(fx(13)); obj* r = FN16(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), fx(10), fx(11), fx(12), fx(13), a1, a2); lean_dec_ref(f); return r; }
   default:
-    lean_assert(arity > 16);
     obj * as[2] = { a1, a2 };
-    obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
-    for (unsigned i = 0; i < 2; i++) args[fixed+i] = as[i];
-    obj * r = FNN(f)(args);
-    lean_dec_ref(f);
-    return r;
+    return apply_packed(f, as, 2);
   }
 } else if (arity < fixed + 2) {
   obj * as[2] = { a1, a2 };
-  obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-  for (unsigned i = 0; i < arity-fixed; i++) args[fixed+i] = as[i];
-  obj * new_f;
-  if (lean_is_exclusive(f)) {
-    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
-    new_f = curry(f, arity, args);
-    lean_free_object(f);
-  } else {
-    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
-    new_f = curry(f, arity, args);
-    lean_dec_ref(f);
-  }
-  return lean_apply_n(new_f, 2+fixed-arity, &as[arity-fixed]);
+  return apply_oversat(f, as, 2);
 } else {
   return fix_args(f, {a1, a2});
 }
@@ -265,15 +264,6 @@ if (arity == fixed + 3) {
     case 14: { obj* r = FN14(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), fx(10), a1, a2, a3); lean_free_object(f); return r; }
     case 15: { obj* r = FN15(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), fx(10), fx(11), a1, a2, a3); lean_free_object(f); return r; }
     case 16: { obj* r = FN16(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), fx(10), fx(11), fx(12), a1, a2, a3); lean_free_object(f); return r; }
-    default:
-      lean_assert(arity > 16);
-      obj * as[3] = { a1, a2, a3 };
-      obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-      for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
-      for (unsigned i = 0; i < 3; i++) args[fixed+i] = as[i];
-      obj * r = FNN(f)(args);
-      lean_free_object(f);
-      return r;
     }
   }
   switch (arity) {
@@ -292,30 +282,12 @@ if (arity == fixed + 3) {
   case 15: { lean_inc(fx(0)); lean_inc(fx(1)); lean_inc(fx(2)); lean_inc(fx(3)); lean_inc(fx(4)); lean_inc(fx(5)); lean_inc(fx(6)); lean_inc(fx(7)); lean_inc(fx(8)); lean_inc(fx(9)); lean_inc(fx(10)); lean_inc(fx(11)); obj* r = FN15(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), fx(10), fx(11), a1, a2, a3); lean_dec_ref(f); return r; }
   case 16: { lean_inc(fx(0)); lean_inc(fx(1)); lean_inc(fx(2)); lean_inc(fx(3)); lean_inc(fx(4)); lean_inc(fx(5)); lean_inc(fx(6)); lean_inc(fx(7)); lean_inc(fx(8)); lean_inc(fx(9)); lean_inc(fx(10)); lean_inc(fx(11)); lean_inc(fx(12)); obj* r = FN16(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), fx(10), fx(11), fx(12), a1, a2, a3); lean_dec_ref(f); return r; }
   default:
-    lean_assert(arity > 16);
     obj * as[3] = { a1, a2, a3 };
-    obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
-    for (unsigned i = 0; i < 3; i++) args[fixed+i] = as[i];
-    obj * r = FNN(f)(args);
-    lean_dec_ref(f);
-    return r;
+    return apply_packed(f, as, 3);
   }
 } else if (arity < fixed + 3) {
   obj * as[3] = { a1, a2, a3 };
-  obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-  for (unsigned i = 0; i < arity-fixed; i++) args[fixed+i] = as[i];
-  obj * new_f;
-  if (lean_is_exclusive(f)) {
-    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
-    new_f = curry(f, arity, args);
-    lean_free_object(f);
-  } else {
-    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
-    new_f = curry(f, arity, args);
-    lean_dec_ref(f);
-  }
-  return lean_apply_n(new_f, 3+fixed-arity, &as[arity-fixed]);
+  return apply_oversat(f, as, 3);
 } else {
   return fix_args(f, {a1, a2, a3});
 }
@@ -340,15 +312,6 @@ if (arity == fixed + 4) {
     case 14: { obj* r = FN14(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), a1, a2, a3, a4); lean_free_object(f); return r; }
     case 15: { obj* r = FN15(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), fx(10), a1, a2, a3, a4); lean_free_object(f); return r; }
     case 16: { obj* r = FN16(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), fx(10), fx(11), a1, a2, a3, a4); lean_free_object(f); return r; }
-    default:
-      lean_assert(arity > 16);
-      obj * as[4] = { a1, a2, a3, a4 };
-      obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-      for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
-      for (unsigned i = 0; i < 4; i++) args[fixed+i] = as[i];
-      obj * r = FNN(f)(args);
-      lean_free_object(f);
-      return r;
     }
   }
   switch (arity) {
@@ -366,30 +329,12 @@ if (arity == fixed + 4) {
   case 15: { lean_inc(fx(0)); lean_inc(fx(1)); lean_inc(fx(2)); lean_inc(fx(3)); lean_inc(fx(4)); lean_inc(fx(5)); lean_inc(fx(6)); lean_inc(fx(7)); lean_inc(fx(8)); lean_inc(fx(9)); lean_inc(fx(10)); obj* r = FN15(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), fx(10), a1, a2, a3, a4); lean_dec_ref(f); return r; }
   case 16: { lean_inc(fx(0)); lean_inc(fx(1)); lean_inc(fx(2)); lean_inc(fx(3)); lean_inc(fx(4)); lean_inc(fx(5)); lean_inc(fx(6)); lean_inc(fx(7)); lean_inc(fx(8)); lean_inc(fx(9)); lean_inc(fx(10)); lean_inc(fx(11)); obj* r = FN16(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), fx(10), fx(11), a1, a2, a3, a4); lean_dec_ref(f); return r; }
   default:
-    lean_assert(arity > 16);
     obj * as[4] = { a1, a2, a3, a4 };
-    obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
-    for (unsigned i = 0; i < 4; i++) args[fixed+i] = as[i];
-    obj * r = FNN(f)(args);
-    lean_dec_ref(f);
-    return r;
+    return apply_packed(f, as, 4);
   }
 } else if (arity < fixed + 4) {
   obj * as[4] = { a1, a2, a3, a4 };
-  obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-  for (unsigned i = 0; i < arity-fixed; i++) args[fixed+i] = as[i];
-  obj * new_f;
-  if (lean_is_exclusive(f)) {
-    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
-    new_f = curry(f, arity, args);
-    lean_free_object(f);
-  } else {
-    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
-    new_f = curry(f, arity, args);
-    lean_dec_ref(f);
-  }
-  return lean_apply_n(new_f, 4+fixed-arity, &as[arity-fixed]);
+  return apply_oversat(f, as, 4);
 } else {
   return fix_args(f, {a1, a2, a3, a4});
 }
@@ -413,15 +358,6 @@ if (arity == fixed + 5) {
     case 14: { obj* r = FN14(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), a1, a2, a3, a4, a5); lean_free_object(f); return r; }
     case 15: { obj* r = FN15(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), a1, a2, a3, a4, a5); lean_free_object(f); return r; }
     case 16: { obj* r = FN16(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), fx(10), a1, a2, a3, a4, a5); lean_free_object(f); return r; }
-    default:
-      lean_assert(arity > 16);
-      obj * as[5] = { a1, a2, a3, a4, a5 };
-      obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-      for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
-      for (unsigned i = 0; i < 5; i++) args[fixed+i] = as[i];
-      obj * r = FNN(f)(args);
-      lean_free_object(f);
-      return r;
     }
   }
   switch (arity) {
@@ -438,30 +374,12 @@ if (arity == fixed + 5) {
   case 15: { lean_inc(fx(0)); lean_inc(fx(1)); lean_inc(fx(2)); lean_inc(fx(3)); lean_inc(fx(4)); lean_inc(fx(5)); lean_inc(fx(6)); lean_inc(fx(7)); lean_inc(fx(8)); lean_inc(fx(9)); obj* r = FN15(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), a1, a2, a3, a4, a5); lean_dec_ref(f); return r; }
   case 16: { lean_inc(fx(0)); lean_inc(fx(1)); lean_inc(fx(2)); lean_inc(fx(3)); lean_inc(fx(4)); lean_inc(fx(5)); lean_inc(fx(6)); lean_inc(fx(7)); lean_inc(fx(8)); lean_inc(fx(9)); lean_inc(fx(10)); obj* r = FN16(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), fx(10), a1, a2, a3, a4, a5); lean_dec_ref(f); return r; }
   default:
-    lean_assert(arity > 16);
     obj * as[5] = { a1, a2, a3, a4, a5 };
-    obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
-    for (unsigned i = 0; i < 5; i++) args[fixed+i] = as[i];
-    obj * r = FNN(f)(args);
-    lean_dec_ref(f);
-    return r;
+    return apply_packed(f, as, 5);
   }
 } else if (arity < fixed + 5) {
   obj * as[5] = { a1, a2, a3, a4, a5 };
-  obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-  for (unsigned i = 0; i < arity-fixed; i++) args[fixed+i] = as[i];
-  obj * new_f;
-  if (lean_is_exclusive(f)) {
-    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
-    new_f = curry(f, arity, args);
-    lean_free_object(f);
-  } else {
-    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
-    new_f = curry(f, arity, args);
-    lean_dec_ref(f);
-  }
-  return lean_apply_n(new_f, 5+fixed-arity, &as[arity-fixed]);
+  return apply_oversat(f, as, 5);
 } else {
   return fix_args(f, {a1, a2, a3, a4, a5});
 }
@@ -484,15 +402,6 @@ if (arity == fixed + 6) {
     case 14: { obj* r = FN14(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), a1, a2, a3, a4, a5, a6); lean_free_object(f); return r; }
     case 15: { obj* r = FN15(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), a1, a2, a3, a4, a5, a6); lean_free_object(f); return r; }
     case 16: { obj* r = FN16(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), a1, a2, a3, a4, a5, a6); lean_free_object(f); return r; }
-    default:
-      lean_assert(arity > 16);
-      obj * as[6] = { a1, a2, a3, a4, a5, a6 };
-      obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-      for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
-      for (unsigned i = 0; i < 6; i++) args[fixed+i] = as[i];
-      obj * r = FNN(f)(args);
-      lean_free_object(f);
-      return r;
     }
   }
   switch (arity) {
@@ -508,30 +417,12 @@ if (arity == fixed + 6) {
   case 15: { lean_inc(fx(0)); lean_inc(fx(1)); lean_inc(fx(2)); lean_inc(fx(3)); lean_inc(fx(4)); lean_inc(fx(5)); lean_inc(fx(6)); lean_inc(fx(7)); lean_inc(fx(8)); obj* r = FN15(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), a1, a2, a3, a4, a5, a6); lean_dec_ref(f); return r; }
   case 16: { lean_inc(fx(0)); lean_inc(fx(1)); lean_inc(fx(2)); lean_inc(fx(3)); lean_inc(fx(4)); lean_inc(fx(5)); lean_inc(fx(6)); lean_inc(fx(7)); lean_inc(fx(8)); lean_inc(fx(9)); obj* r = FN16(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), fx(9), a1, a2, a3, a4, a5, a6); lean_dec_ref(f); return r; }
   default:
-    lean_assert(arity > 16);
     obj * as[6] = { a1, a2, a3, a4, a5, a6 };
-    obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
-    for (unsigned i = 0; i < 6; i++) args[fixed+i] = as[i];
-    obj * r = FNN(f)(args);
-    lean_dec_ref(f);
-    return r;
+    return apply_packed(f, as, 6);
   }
 } else if (arity < fixed + 6) {
   obj * as[6] = { a1, a2, a3, a4, a5, a6 };
-  obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-  for (unsigned i = 0; i < arity-fixed; i++) args[fixed+i] = as[i];
-  obj * new_f;
-  if (lean_is_exclusive(f)) {
-    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
-    new_f = curry(f, arity, args);
-    lean_free_object(f);
-  } else {
-    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
-    new_f = curry(f, arity, args);
-    lean_dec_ref(f);
-  }
-  return lean_apply_n(new_f, 6+fixed-arity, &as[arity-fixed]);
+  return apply_oversat(f, as, 6);
 } else {
   return fix_args(f, {a1, a2, a3, a4, a5, a6});
 }
@@ -553,15 +444,6 @@ if (arity == fixed + 7) {
     case 14: { obj* r = FN14(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), a1, a2, a3, a4, a5, a6, a7); lean_free_object(f); return r; }
     case 15: { obj* r = FN15(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), a1, a2, a3, a4, a5, a6, a7); lean_free_object(f); return r; }
     case 16: { obj* r = FN16(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), a1, a2, a3, a4, a5, a6, a7); lean_free_object(f); return r; }
-    default:
-      lean_assert(arity > 16);
-      obj * as[7] = { a1, a2, a3, a4, a5, a6, a7 };
-      obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-      for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
-      for (unsigned i = 0; i < 7; i++) args[fixed+i] = as[i];
-      obj * r = FNN(f)(args);
-      lean_free_object(f);
-      return r;
     }
   }
   switch (arity) {
@@ -576,30 +458,12 @@ if (arity == fixed + 7) {
   case 15: { lean_inc(fx(0)); lean_inc(fx(1)); lean_inc(fx(2)); lean_inc(fx(3)); lean_inc(fx(4)); lean_inc(fx(5)); lean_inc(fx(6)); lean_inc(fx(7)); obj* r = FN15(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), a1, a2, a3, a4, a5, a6, a7); lean_dec_ref(f); return r; }
   case 16: { lean_inc(fx(0)); lean_inc(fx(1)); lean_inc(fx(2)); lean_inc(fx(3)); lean_inc(fx(4)); lean_inc(fx(5)); lean_inc(fx(6)); lean_inc(fx(7)); lean_inc(fx(8)); obj* r = FN16(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), fx(8), a1, a2, a3, a4, a5, a6, a7); lean_dec_ref(f); return r; }
   default:
-    lean_assert(arity > 16);
     obj * as[7] = { a1, a2, a3, a4, a5, a6, a7 };
-    obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
-    for (unsigned i = 0; i < 7; i++) args[fixed+i] = as[i];
-    obj * r = FNN(f)(args);
-    lean_dec_ref(f);
-    return r;
+    return apply_packed(f, as, 7);
   }
 } else if (arity < fixed + 7) {
   obj * as[7] = { a1, a2, a3, a4, a5, a6, a7 };
-  obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-  for (unsigned i = 0; i < arity-fixed; i++) args[fixed+i] = as[i];
-  obj * new_f;
-  if (lean_is_exclusive(f)) {
-    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
-    new_f = curry(f, arity, args);
-    lean_free_object(f);
-  } else {
-    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
-    new_f = curry(f, arity, args);
-    lean_dec_ref(f);
-  }
-  return lean_apply_n(new_f, 7+fixed-arity, &as[arity-fixed]);
+  return apply_oversat(f, as, 7);
 } else {
   return fix_args(f, {a1, a2, a3, a4, a5, a6, a7});
 }
@@ -620,15 +484,6 @@ if (arity == fixed + 8) {
     case 14: { obj* r = FN14(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), a1, a2, a3, a4, a5, a6, a7, a8); lean_free_object(f); return r; }
     case 15: { obj* r = FN15(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), a1, a2, a3, a4, a5, a6, a7, a8); lean_free_object(f); return r; }
     case 16: { obj* r = FN16(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), a1, a2, a3, a4, a5, a6, a7, a8); lean_free_object(f); return r; }
-    default:
-      lean_assert(arity > 16);
-      obj * as[8] = { a1, a2, a3, a4, a5, a6, a7, a8 };
-      obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-      for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
-      for (unsigned i = 0; i < 8; i++) args[fixed+i] = as[i];
-      obj * r = FNN(f)(args);
-      lean_free_object(f);
-      return r;
     }
   }
   switch (arity) {
@@ -642,30 +497,12 @@ if (arity == fixed + 8) {
   case 15: { lean_inc(fx(0)); lean_inc(fx(1)); lean_inc(fx(2)); lean_inc(fx(3)); lean_inc(fx(4)); lean_inc(fx(5)); lean_inc(fx(6)); obj* r = FN15(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), a1, a2, a3, a4, a5, a6, a7, a8); lean_dec_ref(f); return r; }
   case 16: { lean_inc(fx(0)); lean_inc(fx(1)); lean_inc(fx(2)); lean_inc(fx(3)); lean_inc(fx(4)); lean_inc(fx(5)); lean_inc(fx(6)); lean_inc(fx(7)); obj* r = FN16(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), fx(7), a1, a2, a3, a4, a5, a6, a7, a8); lean_dec_ref(f); return r; }
   default:
-    lean_assert(arity > 16);
     obj * as[8] = { a1, a2, a3, a4, a5, a6, a7, a8 };
-    obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
-    for (unsigned i = 0; i < 8; i++) args[fixed+i] = as[i];
-    obj * r = FNN(f)(args);
-    lean_dec_ref(f);
-    return r;
+    return apply_packed(f, as, 8);
   }
 } else if (arity < fixed + 8) {
   obj * as[8] = { a1, a2, a3, a4, a5, a6, a7, a8 };
-  obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-  for (unsigned i = 0; i < arity-fixed; i++) args[fixed+i] = as[i];
-  obj * new_f;
-  if (lean_is_exclusive(f)) {
-    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
-    new_f = curry(f, arity, args);
-    lean_free_object(f);
-  } else {
-    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
-    new_f = curry(f, arity, args);
-    lean_dec_ref(f);
-  }
-  return lean_apply_n(new_f, 8+fixed-arity, &as[arity-fixed]);
+  return apply_oversat(f, as, 8);
 } else {
   return fix_args(f, {a1, a2, a3, a4, a5, a6, a7, a8});
 }
@@ -685,15 +522,6 @@ if (arity == fixed + 9) {
     case 14: { obj* r = FN14(f)(fx(0), fx(1), fx(2), fx(3), fx(4), a1, a2, a3, a4, a5, a6, a7, a8, a9); lean_free_object(f); return r; }
     case 15: { obj* r = FN15(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), a1, a2, a3, a4, a5, a6, a7, a8, a9); lean_free_object(f); return r; }
     case 16: { obj* r = FN16(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), a1, a2, a3, a4, a5, a6, a7, a8, a9); lean_free_object(f); return r; }
-    default:
-      lean_assert(arity > 16);
-      obj * as[9] = { a1, a2, a3, a4, a5, a6, a7, a8, a9 };
-      obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-      for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
-      for (unsigned i = 0; i < 9; i++) args[fixed+i] = as[i];
-      obj * r = FNN(f)(args);
-      lean_free_object(f);
-      return r;
     }
   }
   switch (arity) {
@@ -706,30 +534,12 @@ if (arity == fixed + 9) {
   case 15: { lean_inc(fx(0)); lean_inc(fx(1)); lean_inc(fx(2)); lean_inc(fx(3)); lean_inc(fx(4)); lean_inc(fx(5)); obj* r = FN15(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), a1, a2, a3, a4, a5, a6, a7, a8, a9); lean_dec_ref(f); return r; }
   case 16: { lean_inc(fx(0)); lean_inc(fx(1)); lean_inc(fx(2)); lean_inc(fx(3)); lean_inc(fx(4)); lean_inc(fx(5)); lean_inc(fx(6)); obj* r = FN16(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), fx(6), a1, a2, a3, a4, a5, a6, a7, a8, a9); lean_dec_ref(f); return r; }
   default:
-    lean_assert(arity > 16);
     obj * as[9] = { a1, a2, a3, a4, a5, a6, a7, a8, a9 };
-    obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
-    for (unsigned i = 0; i < 9; i++) args[fixed+i] = as[i];
-    obj * r = FNN(f)(args);
-    lean_dec_ref(f);
-    return r;
+    return apply_packed(f, as, 9);
   }
 } else if (arity < fixed + 9) {
   obj * as[9] = { a1, a2, a3, a4, a5, a6, a7, a8, a9 };
-  obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-  for (unsigned i = 0; i < arity-fixed; i++) args[fixed+i] = as[i];
-  obj * new_f;
-  if (lean_is_exclusive(f)) {
-    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
-    new_f = curry(f, arity, args);
-    lean_free_object(f);
-  } else {
-    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
-    new_f = curry(f, arity, args);
-    lean_dec_ref(f);
-  }
-  return lean_apply_n(new_f, 9+fixed-arity, &as[arity-fixed]);
+  return apply_oversat(f, as, 9);
 } else {
   return fix_args(f, {a1, a2, a3, a4, a5, a6, a7, a8, a9});
 }
@@ -748,15 +558,6 @@ if (arity == fixed + 10) {
     case 14: { obj* r = FN14(f)(fx(0), fx(1), fx(2), fx(3), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10); lean_free_object(f); return r; }
     case 15: { obj* r = FN15(f)(fx(0), fx(1), fx(2), fx(3), fx(4), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10); lean_free_object(f); return r; }
     case 16: { obj* r = FN16(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10); lean_free_object(f); return r; }
-    default:
-      lean_assert(arity > 16);
-      obj * as[10] = { a1, a2, a3, a4, a5, a6, a7, a8, a9, a10 };
-      obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-      for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
-      for (unsigned i = 0; i < 10; i++) args[fixed+i] = as[i];
-      obj * r = FNN(f)(args);
-      lean_free_object(f);
-      return r;
     }
   }
   switch (arity) {
@@ -768,30 +569,12 @@ if (arity == fixed + 10) {
   case 15: { lean_inc(fx(0)); lean_inc(fx(1)); lean_inc(fx(2)); lean_inc(fx(3)); lean_inc(fx(4)); obj* r = FN15(f)(fx(0), fx(1), fx(2), fx(3), fx(4), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10); lean_dec_ref(f); return r; }
   case 16: { lean_inc(fx(0)); lean_inc(fx(1)); lean_inc(fx(2)); lean_inc(fx(3)); lean_inc(fx(4)); lean_inc(fx(5)); obj* r = FN16(f)(fx(0), fx(1), fx(2), fx(3), fx(4), fx(5), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10); lean_dec_ref(f); return r; }
   default:
-    lean_assert(arity > 16);
     obj * as[10] = { a1, a2, a3, a4, a5, a6, a7, a8, a9, a10 };
-    obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
-    for (unsigned i = 0; i < 10; i++) args[fixed+i] = as[i];
-    obj * r = FNN(f)(args);
-    lean_dec_ref(f);
-    return r;
+    return apply_packed(f, as, 10);
   }
 } else if (arity < fixed + 10) {
   obj * as[10] = { a1, a2, a3, a4, a5, a6, a7, a8, a9, a10 };
-  obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-  for (unsigned i = 0; i < arity-fixed; i++) args[fixed+i] = as[i];
-  obj * new_f;
-  if (lean_is_exclusive(f)) {
-    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
-    new_f = curry(f, arity, args);
-    lean_free_object(f);
-  } else {
-    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
-    new_f = curry(f, arity, args);
-    lean_dec_ref(f);
-  }
-  return lean_apply_n(new_f, 10+fixed-arity, &as[arity-fixed]);
+  return apply_oversat(f, as, 10);
 } else {
   return fix_args(f, {a1, a2, a3, a4, a5, a6, a7, a8, a9, a10});
 }
@@ -809,15 +592,6 @@ if (arity == fixed + 11) {
     case 14: { obj* r = FN14(f)(fx(0), fx(1), fx(2), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11); lean_free_object(f); return r; }
     case 15: { obj* r = FN15(f)(fx(0), fx(1), fx(2), fx(3), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11); lean_free_object(f); return r; }
     case 16: { obj* r = FN16(f)(fx(0), fx(1), fx(2), fx(3), fx(4), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11); lean_free_object(f); return r; }
-    default:
-      lean_assert(arity > 16);
-      obj * as[11] = { a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11 };
-      obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-      for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
-      for (unsigned i = 0; i < 11; i++) args[fixed+i] = as[i];
-      obj * r = FNN(f)(args);
-      lean_free_object(f);
-      return r;
     }
   }
   switch (arity) {
@@ -828,30 +602,12 @@ if (arity == fixed + 11) {
   case 15: { lean_inc(fx(0)); lean_inc(fx(1)); lean_inc(fx(2)); lean_inc(fx(3)); obj* r = FN15(f)(fx(0), fx(1), fx(2), fx(3), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11); lean_dec_ref(f); return r; }
   case 16: { lean_inc(fx(0)); lean_inc(fx(1)); lean_inc(fx(2)); lean_inc(fx(3)); lean_inc(fx(4)); obj* r = FN16(f)(fx(0), fx(1), fx(2), fx(3), fx(4), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11); lean_dec_ref(f); return r; }
   default:
-    lean_assert(arity > 16);
     obj * as[11] = { a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11 };
-    obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
-    for (unsigned i = 0; i < 11; i++) args[fixed+i] = as[i];
-    obj * r = FNN(f)(args);
-    lean_dec_ref(f);
-    return r;
+    return apply_packed(f, as, 11);
   }
 } else if (arity < fixed + 11) {
   obj * as[11] = { a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11 };
-  obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-  for (unsigned i = 0; i < arity-fixed; i++) args[fixed+i] = as[i];
-  obj * new_f;
-  if (lean_is_exclusive(f)) {
-    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
-    new_f = curry(f, arity, args);
-    lean_free_object(f);
-  } else {
-    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
-    new_f = curry(f, arity, args);
-    lean_dec_ref(f);
-  }
-  return lean_apply_n(new_f, 11+fixed-arity, &as[arity-fixed]);
+  return apply_oversat(f, as, 11);
 } else {
   return fix_args(f, {a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11});
 }
@@ -868,15 +624,6 @@ if (arity == fixed + 12) {
     case 14: { obj* r = FN14(f)(fx(0), fx(1), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12); lean_free_object(f); return r; }
     case 15: { obj* r = FN15(f)(fx(0), fx(1), fx(2), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12); lean_free_object(f); return r; }
     case 16: { obj* r = FN16(f)(fx(0), fx(1), fx(2), fx(3), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12); lean_free_object(f); return r; }
-    default:
-      lean_assert(arity > 16);
-      obj * as[12] = { a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12 };
-      obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-      for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
-      for (unsigned i = 0; i < 12; i++) args[fixed+i] = as[i];
-      obj * r = FNN(f)(args);
-      lean_free_object(f);
-      return r;
     }
   }
   switch (arity) {
@@ -886,30 +633,12 @@ if (arity == fixed + 12) {
   case 15: { lean_inc(fx(0)); lean_inc(fx(1)); lean_inc(fx(2)); obj* r = FN15(f)(fx(0), fx(1), fx(2), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12); lean_dec_ref(f); return r; }
   case 16: { lean_inc(fx(0)); lean_inc(fx(1)); lean_inc(fx(2)); lean_inc(fx(3)); obj* r = FN16(f)(fx(0), fx(1), fx(2), fx(3), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12); lean_dec_ref(f); return r; }
   default:
-    lean_assert(arity > 16);
     obj * as[12] = { a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12 };
-    obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
-    for (unsigned i = 0; i < 12; i++) args[fixed+i] = as[i];
-    obj * r = FNN(f)(args);
-    lean_dec_ref(f);
-    return r;
+    return apply_packed(f, as, 12);
   }
 } else if (arity < fixed + 12) {
   obj * as[12] = { a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12 };
-  obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-  for (unsigned i = 0; i < arity-fixed; i++) args[fixed+i] = as[i];
-  obj * new_f;
-  if (lean_is_exclusive(f)) {
-    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
-    new_f = curry(f, arity, args);
-    lean_free_object(f);
-  } else {
-    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
-    new_f = curry(f, arity, args);
-    lean_dec_ref(f);
-  }
-  return lean_apply_n(new_f, 12+fixed-arity, &as[arity-fixed]);
+  return apply_oversat(f, as, 12);
 } else {
   return fix_args(f, {a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12});
 }
@@ -925,15 +654,6 @@ if (arity == fixed + 13) {
     case 14: { obj* r = FN14(f)(fx(0), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13); lean_free_object(f); return r; }
     case 15: { obj* r = FN15(f)(fx(0), fx(1), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13); lean_free_object(f); return r; }
     case 16: { obj* r = FN16(f)(fx(0), fx(1), fx(2), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13); lean_free_object(f); return r; }
-    default:
-      lean_assert(arity > 16);
-      obj * as[13] = { a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13 };
-      obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-      for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
-      for (unsigned i = 0; i < 13; i++) args[fixed+i] = as[i];
-      obj * r = FNN(f)(args);
-      lean_free_object(f);
-      return r;
     }
   }
   switch (arity) {
@@ -942,30 +662,12 @@ if (arity == fixed + 13) {
   case 15: { lean_inc(fx(0)); lean_inc(fx(1)); obj* r = FN15(f)(fx(0), fx(1), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13); lean_dec_ref(f); return r; }
   case 16: { lean_inc(fx(0)); lean_inc(fx(1)); lean_inc(fx(2)); obj* r = FN16(f)(fx(0), fx(1), fx(2), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13); lean_dec_ref(f); return r; }
   default:
-    lean_assert(arity > 16);
     obj * as[13] = { a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13 };
-    obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
-    for (unsigned i = 0; i < 13; i++) args[fixed+i] = as[i];
-    obj * r = FNN(f)(args);
-    lean_dec_ref(f);
-    return r;
+    return apply_packed(f, as, 13);
   }
 } else if (arity < fixed + 13) {
   obj * as[13] = { a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13 };
-  obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-  for (unsigned i = 0; i < arity-fixed; i++) args[fixed+i] = as[i];
-  obj * new_f;
-  if (lean_is_exclusive(f)) {
-    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
-    new_f = curry(f, arity, args);
-    lean_free_object(f);
-  } else {
-    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
-    new_f = curry(f, arity, args);
-    lean_dec_ref(f);
-  }
-  return lean_apply_n(new_f, 13+fixed-arity, &as[arity-fixed]);
+  return apply_oversat(f, as, 13);
 } else {
   return fix_args(f, {a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13});
 }
@@ -980,15 +682,6 @@ if (arity == fixed + 14) {
     case 14: { obj* r = FN14(f)(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14); lean_free_object(f); return r; }
     case 15: { obj* r = FN15(f)(fx(0), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14); lean_free_object(f); return r; }
     case 16: { obj* r = FN16(f)(fx(0), fx(1), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14); lean_free_object(f); return r; }
-    default:
-      lean_assert(arity > 16);
-      obj * as[14] = { a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14 };
-      obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-      for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
-      for (unsigned i = 0; i < 14; i++) args[fixed+i] = as[i];
-      obj * r = FNN(f)(args);
-      lean_free_object(f);
-      return r;
     }
   }
   switch (arity) {
@@ -996,30 +689,12 @@ if (arity == fixed + 14) {
   case 15: { lean_inc(fx(0)); obj* r = FN15(f)(fx(0), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14); lean_dec_ref(f); return r; }
   case 16: { lean_inc(fx(0)); lean_inc(fx(1)); obj* r = FN16(f)(fx(0), fx(1), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14); lean_dec_ref(f); return r; }
   default:
-    lean_assert(arity > 16);
     obj * as[14] = { a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14 };
-    obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
-    for (unsigned i = 0; i < 14; i++) args[fixed+i] = as[i];
-    obj * r = FNN(f)(args);
-    lean_dec_ref(f);
-    return r;
+    return apply_packed(f, as, 14);
   }
 } else if (arity < fixed + 14) {
   obj * as[14] = { a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14 };
-  obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-  for (unsigned i = 0; i < arity-fixed; i++) args[fixed+i] = as[i];
-  obj * new_f;
-  if (lean_is_exclusive(f)) {
-    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
-    new_f = curry(f, arity, args);
-    lean_free_object(f);
-  } else {
-    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
-    new_f = curry(f, arity, args);
-    lean_dec_ref(f);
-  }
-  return lean_apply_n(new_f, 14+fixed-arity, &as[arity-fixed]);
+  return apply_oversat(f, as, 14);
 } else {
   return fix_args(f, {a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14});
 }
@@ -1033,45 +708,18 @@ if (arity == fixed + 15) {
     switch (arity) {
     case 15: { obj* r = FN15(f)(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15); lean_free_object(f); return r; }
     case 16: { obj* r = FN16(f)(fx(0), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15); lean_free_object(f); return r; }
-    default:
-      lean_assert(arity > 16);
-      obj * as[15] = { a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15 };
-      obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-      for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
-      for (unsigned i = 0; i < 15; i++) args[fixed+i] = as[i];
-      obj * r = FNN(f)(args);
-      lean_free_object(f);
-      return r;
     }
   }
   switch (arity) {
   case 15: { obj* r = FN15(f)(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15); lean_dec_ref(f); return r; }
   case 16: { lean_inc(fx(0)); obj* r = FN16(f)(fx(0), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15); lean_dec_ref(f); return r; }
   default:
-    lean_assert(arity > 16);
     obj * as[15] = { a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15 };
-    obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
-    for (unsigned i = 0; i < 15; i++) args[fixed+i] = as[i];
-    obj * r = FNN(f)(args);
-    lean_dec_ref(f);
-    return r;
+    return apply_packed(f, as, 15);
   }
 } else if (arity < fixed + 15) {
   obj * as[15] = { a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15 };
-  obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-  for (unsigned i = 0; i < arity-fixed; i++) args[fixed+i] = as[i];
-  obj * new_f;
-  if (lean_is_exclusive(f)) {
-    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
-    new_f = curry(f, arity, args);
-    lean_free_object(f);
-  } else {
-    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
-    new_f = curry(f, arity, args);
-    lean_dec_ref(f);
-  }
-  return lean_apply_n(new_f, 15+fixed-arity, &as[arity-fixed]);
+  return apply_oversat(f, as, 15);
 } else {
   return fix_args(f, {a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15});
 }
@@ -1084,44 +732,17 @@ if (arity == fixed + 16) {
   if (lean_is_exclusive(f)) {
     switch (arity) {
     case 16: { obj* r = FN16(f)(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16); lean_free_object(f); return r; }
-    default:
-      lean_assert(arity > 16);
-      obj * as[16] = { a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16 };
-      obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-      for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
-      for (unsigned i = 0; i < 16; i++) args[fixed+i] = as[i];
-      obj * r = FNN(f)(args);
-      lean_free_object(f);
-      return r;
     }
   }
   switch (arity) {
   case 16: { obj* r = FN16(f)(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16); lean_dec_ref(f); return r; }
   default:
-    lean_assert(arity > 16);
     obj * as[16] = { a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16 };
-    obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
-    for (unsigned i = 0; i < 16; i++) args[fixed+i] = as[i];
-    obj * r = FNN(f)(args);
-    lean_dec_ref(f);
-    return r;
+    return apply_packed(f, as, 16);
   }
 } else if (arity < fixed + 16) {
   obj * as[16] = { a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16 };
-  obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-  for (unsigned i = 0; i < arity-fixed; i++) args[fixed+i] = as[i];
-  obj * new_f;
-  if (lean_is_exclusive(f)) {
-    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
-    new_f = curry(f, arity, args);
-    lean_free_object(f);
-  } else {
-    for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
-    new_f = curry(f, arity, args);
-    lean_dec_ref(f);
-  }
-  return lean_apply_n(new_f, 16+fixed-arity, &as[arity-fixed]);
+  return apply_oversat(f, as, 16);
 } else {
   return fix_args(f, {a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16});
 }
@@ -1132,34 +753,13 @@ if (lean_is_scalar(f)) { for (unsigned i = 0; i < n; i++) { lean_dec(as[i]); } r
 unsigned arity = lean_closure_arity(f);
 unsigned fixed = lean_closure_num_fixed(f);
 if (arity == fixed + n) {
-  obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-  for (unsigned i = 0; i < n; i++) args[fixed+i] = as[i];
-  if (lean_is_exclusive(f)) {
-    for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
-    obj * r = FNN(f)(args);
-    lean_free_object(f);
-    return r;
-  }
-  for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
-  obj * r = FNN(f)(args);
-  lean_dec_ref(f);
-  return r;
+  return apply_packed(f, as, n);
 } else if (arity < fixed + n) {
   unsigned m = arity - fixed;
   obj * new_f;
   if (arity > LEAN_CLOSURE_MAX_ARGS) {
     // `f`'s code takes its arguments as an array
-    obj ** args = static_cast<obj**>(LEAN_ALLOCA(arity*sizeof(obj*))); // NOLINT
-    for (unsigned i = 0; i < m; i++) args[fixed+i] = as[i];
-    if (lean_is_exclusive(f)) {
-      for (unsigned i = 0; i < fixed; i++) args[i] = fx(i);
-      new_f = FNN(f)(args);
-      lean_free_object(f);
-    } else {
-      for (unsigned i = 0; i < fixed; i++) { lean_inc(fx(i)); args[i] = fx(i); }
-      new_f = FNN(f)(args);
-      lean_dec_ref(f);
-    }
+    new_f = apply_packed(f, as, m);
   } else {
     // `f`'s code takes `arity` separate arguments, so it must not be invoked through `FNN`;
     // `lean_apply_n` dispatches on `m` and consumes `f`.

--- a/tests/elab/closure_16_unique.lean
+++ b/tests/elab/closure_16_unique.lean
@@ -1,0 +1,41 @@
+/-!
+This test asserts that closures with more than 16 arguments do pass their arguments uniquely if
+they are themselves also unique.
+-/
+
+unsafe def long (arr : Array Nat) (a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 : Nat) :=
+  let addr := ptrAddrUnsafe arr
+  let arr :=
+    arr
+      |>.push a1
+      |>.push a2
+      |>.push a3
+      |>.push a4
+      |>.push a5
+      |>.push a6
+      |>.push a7
+      |>.push a8
+      |>.push a9
+      |>.push a10
+      |>.push a11
+      |>.push a12
+      |>.push a13
+      |>.push a14
+      |>.push a15
+      |>.push a16
+      |>.push a17
+  let addr' := ptrAddrUnsafe arr
+  addr == addr'
+
+@[noinline]
+def test (f : Nat → Bool) := f 1
+
+unsafe def doIt (n : Nat) :=
+  let arr := Array.emptyWithCapacity (n + 32)
+  let closure := long arr n n n n n n n n n n n n n n n n
+  test closure
+
+/-- info: true -/
+#guard_msgs in
+#eval doIt 42
+


### PR DESCRIPTION
This PR introduces new fast paths to high arity closure applications. Previously, they would always maintain ownership of their arguments as they pass them to their underlying function pointer, causing non-linearities. This PR introduces the same fast paths as with the other low arity closures for passing the arguments linearly if the closure is passed linearly.