### PR TITLE
feat: keep non-standard axioms out of the `lake check` export

### DIFF
--- a/src/LeanExport/Basic.lean
+++ b/src/LeanExport/Basic.lean
@@ -58,6 +58,8 @@ public structure State where
   exportMData : Bool := false
   exportUnsafe : Bool := false
   ignoreMissing : Bool := false
+  /-- If set, the only axioms a dumped constant may use; see `dumpEnv`. -/
+  permittedAxioms? : Option NameSet := none
   /-- Maps the name of an inductive type to a list of names of corresponding recursors.
   This is used to facilitate exporting of related inductives, constructors, and recursors as a unit. -/
   recursorMap : NameMap NameSet := {}
@@ -416,8 +418,12 @@ public partial def dumpConstant (c : Name) : M Unit := do
       dumpConstant indName
 where
   dumpDeps e := do
-    for c in e.getUsedConstants do
-      dumpConstant c
+    for dep in e.getUsedConstants do
+      if let some permitted := (← get).permittedAxioms? then
+        if let some (.axiomInfo _) := (← read).env.find? dep then
+          unless permitted.contains dep do
+            throw <| .userError s!"Axiom '{dep}' is not permitted; it is used by '{c}'"
+      dumpConstant dep
   /- Return these for inclusion inline with the exported `recInfo`. -/
   dumpRecRule (rule : RecursorRule) : M Json := do
     return Json.mkObj [
@@ -458,16 +464,22 @@ public def dumpMetadata : M Unit := do
 /--
 Exports `constants?` from `env`, or every non-internal constant in scope if none are given.
 
-Each constant is dumped with its dependencies, so the export is closed under them either way.
+Each constant is dumped with its dependencies, so the export is closed under them either way. With
+`permittedAxioms?`, other axioms are left out, and dumping a constant that uses one throws.
 -/
 public def dumpEnv
     (env : Environment) (constants? : Option (List Name) := none) (cliOptions : List String := [])
+    (permittedAxioms? : Option NameSet := none)
 : IO Unit :=
   let constants := constants?.getD (env.constants.toList.map Prod.fst |>.filter (!·.isInternal))
   M.run env do
     let _ ← initState env cliOptions
+    modify fun st => { st with permittedAxioms? }
     dumpMetadata
     for c in constants do
+      if let some permitted := permittedAxioms? then
+        if let some (.axiomInfo _) := env.find? c then
+          unless permitted.contains c do continue
       modify fun st => { st with noMDataExprs := {} }
       dumpConstant c
 

--- a/src/lake/Lake/CLI/Check.lean
+++ b/src/lake/Lake/CLI/Check.lean
@@ -591,7 +591,8 @@ def resolveExternalKernels (cfg : Config) : IO (Except ExitCode (Std.TreeMap Str
       return .error (← cannotRun s!"`{kernelName}` kernel `{kernelCommand[0]!}` was not found")
   return .ok externalKernels
 
-def standardAxioms : Array Lean.Name :=
+/-- The only axioms `lake check` permits. -/
+public def standardAxioms : Array Lean.Name :=
   #[``propext, ``Classical.choice, ``Quot.sound]
 
 /-- Reports the axioms the checked modules rest on, and rejects any beyond `standardAxioms`. -/

--- a/src/lake/Lake/CLI/Main.lean
+++ b/src/lake/Lake/CLI/Main.lean
@@ -1181,9 +1181,9 @@ protected def challenge : CliM PUnit := do
 /--
 The half of `lake check` that runs inside the sandbox, selected by `LAKE_CHECK_EXPORT`.
 
-Resolves the default targets to modules, builds them, and dumps the export of everything in scope.
-The export goes to standard out and everything else to standard error, so the outer half can read
-one from the other.
+Resolves the default targets to modules, builds them, and dumps the export of everything in scope
+but the non-standard axioms, failing if anything uses one. The export goes to standard out and
+everything else to standard error, so the outer half can read one from the other.
 -/
 protected def checkExport : CliM PUnit := do
   let opts ← getThe LakeOptions
@@ -1193,7 +1193,7 @@ protected def checkExport : CliM PUnit := do
   let mods ← ws.runBuild ws.root.defaultModules.fetch buildConfig
   Lean.initSearchPath ws.lakeEnv.lean.sysroot ws.augmentedLeanPath
   let env ← Lean.importModules (mods.map fun mod => {module := mod.name}) {}
-  LeanExport.dumpEnv env
+  LeanExport.dumpEnv env (permittedAxioms? := some (.ofArray Check.standardAxioms))
 
 /-- The `lake check` command: check this project against the kernel. -/
 protected def check : CliM PUnit := do

--- a/tests/lake/tests/check-sorry/test.sh
+++ b/tests/lake/tests/check-sorry/test.sh
@@ -16,8 +16,10 @@ export COMPARATOR_BWRAP="$PWD/../fake-bwrap.sh"
 # this just skips the build.
 "$LAKE" resolve-deps
 
-# The kernel accepts `sorryAx`, so only the axiom report catches this.
+# The kernel accepts `sorryAx`, so only the axiom policy catches this, and the export already
+# refuses it: no kernel gets to run.
 test_status_out 1 "Axiom 'sorryAx' is not permitted" check
 match_text "it is used by 'bad'" produced.out
+no_match_text 'Running Lean default kernel' produced.out
 
 rm -f produced.out

--- a/tests/lake/tests/check-unused-axiom/Solution.lean
+++ b/tests/lake/tests/check-unused-axiom/Solution.lean
@@ -1,0 +1,5 @@
+/-! A project that declares an axiom it never uses, which `lake check` leaves out of its export. -/
+
+axiom unusedAx : (2 : Nat) = 2
+
+theorem ok (n : Nat) : n + 0 = n := rfl

--- a/tests/lake/tests/check-unused-axiom/clean.sh
+++ b/tests/lake/tests/check-unused-axiom/clean.sh
@@ -1,0 +1,1 @@
+rm -rf .lake lake-manifest.json produced.out work

--- a/tests/lake/tests/check-unused-axiom/lakefile.toml
+++ b/tests/lake/tests/check-unused-axiom/lakefile.toml
@@ -1,0 +1,6 @@
+name = "checktest"
+version = "0.1.0"
+defaultTargets = ["Solution"]
+
+[[lean_lib]]
+name = "Solution"

--- a/tests/lake/tests/check-unused-axiom/test.sh
+++ b/tests/lake/tests/check-unused-axiom/test.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+source ../common.sh
+
+./clean.sh
+
+if [ "`uname`" != Linux ]; then
+  echo "Skipping test: lake check needs Linux namespaces"
+  exit 0
+fi
+
+# User namespaces cannot be assumed available in CI containers; see `../fake-bwrap.sh`.
+export COMPARATOR_BWRAP="$PWD/../fake-bwrap.sh"
+
+# `lake check` resolves dependencies inside the sandbox, which cannot write to the project
+# directory, so the manifest has to be in place first.
+"$LAKE" resolve-deps
+
+test_status_out 0 'Lean default kernel accepts the solution' check
+
+# The half of `lake check` that runs inside the sandbox writes the export to standard out: the
+# unused axiom is not in it, while the standard ones are.
+mkdir -p work
+LAKE_CHECK_EXPORT=1 "$LAKE" check > work/export.ndjson
+no_match_text '"str":"unusedAx"' work/export.ndjson
+match_text '"str":"propext"' work/export.ndjson
+
+rm -f produced.out


### PR DESCRIPTION
This PR makes `lake check` leave every axiom other than `propext`, `Classical.choice` and `Quot.sound` out of the export it checks, and fail the export as soon as a declaration uses one, before any kernel runs.