### PR TITLE
feat: lake: uploadable dependency outputs

### DIFF
--- a/src/lake/Lake/Build/Common.lean
+++ b/src/lake/Lake/Build/Common.lean
@@ -665,6 +665,10 @@ public def restoreArtifact (file : FilePath) (art : Artifact) (exe := false) : L
     writeFileHash file art.hash
   return art.useLocalFile file
 
+/-- **For internal use only.** -/
+@[inline] public def Internal.getOutputsRef? [Functor m] [MonadBuild m] (pkg : Package) : m (Option CacheRef) :=
+  readThe BuildContext <&> fun ctx => if pkg.wsIdx = ctx.outputsIdx then ctx.outputsRef? else none
+
 /--
 Uses the current job's trace to search Lake's local artifact cache for an artifact
 with a matching extension (`ext`) and content hash. If one is found, use it.
@@ -724,9 +728,8 @@ public def buildArtifactUnlessUpToDate
           if let some art ← fetchArt? (restore := true) then
             return art
         doBuild depTrace traceFile
-    if pkg.isRoot then
-      if let some outputsRef := (← getBuildContext).outputsRef? then
-        outputsRef.insert inputHash art.descr platformIndependent
+    if let some ref ← Internal.getOutputsRef? pkg then
+      ref.insert inputHash art.descr platformIndependent
     setTrace art.trace
     setMTime art traceFile
   else

--- a/src/lake/Lake/Build/Context.lean
+++ b/src/lake/Lake/Build/Context.lean
@@ -27,8 +27,10 @@ public structure BuildConfig extends LogConfig where
   verbosity : Verbosity := .normal
   /-- Whether to print a message when the build finishes successfully (if not quiet). -/
   showSuccess : Bool := false
-  /-- File to save input-to-output mappings from the build of the workspace's root -/
+  /-- File to save tracked input-to-output mappings from the build of a package. -/
   outputsFile? : Option FilePath := none
+  /-- When tracking input-to-output mappings, the workspace index of the tracked package. -/
+  outputsIdx : Nat := 0
   /--
   Per-package Lean option overrides, applied to every module whose owning
   package's `baseName` appears as a key. When `recFetchSetup` builds module
@@ -86,7 +88,7 @@ public structure BuildContext extends BuildConfig, Context where
   leanIncludeDirs : Array (Option (FilePath × BuildTrace))
   registeredJobs : JobQueue
   /--
-  Input-to-output(s) map for hashes of the root package's artifacts.
+  Input-to-output(s) map for hashes of the tracked package's artifacts.
   If `none`, tracking outputs is disabled for this build.
   -/
   outputsRef? : Option CacheRef := none

--- a/src/lake/Lake/Build/Module.lean
+++ b/src/lake/Lake/Build/Module.lean
@@ -1113,20 +1113,19 @@ where
         else
           mod.buildLean presetup
   trackOutputsIfEnabled arts : JobM ModuleOutputArtifacts := do
-    if mod.pkg.isRoot then
-      if let some ref := (← getBuildContext).outputsRef? then
-        let inputHash := (← getTrace).hash
-        if let some ltar := arts.ltar? then
-          ref.insert inputHash ltar.descr
-          return arts
-        else
-          let ltar ← id do
-            if (← mod.ltarFile.pathExists) then
-              computeArtifact mod.ltarFile "ltar"
-            else
-              mod.packLtar arts
-          ref.insert inputHash ltar.descr (mod.platformIndependent.getD false)
-          return {arts with ltar? := some ltar}
+    if let some ref ← Internal.getOutputsRef? mod.pkg then
+      let inputHash := (← getTrace).hash
+      if let some ltar := arts.ltar? then
+        ref.insert inputHash ltar.descr
+        return arts
+      else
+        let ltar ← id do
+          if (← mod.ltarFile.pathExists) then
+            computeArtifact mod.ltarFile "ltar"
+          else
+            mod.packLtar arts
+        ref.insert inputHash ltar.descr (mod.platformIndependent.getD false)
+        return {arts with ltar? := some ltar}
     return arts
   adjustMTime arts : JobM ModuleOutputArtifacts := do
     match (← getMTime mod.traceFile |>.toBaseIO) with

--- a/src/lake/Lake/Build/Run.lean
+++ b/src/lake/Lake/Build/Run.lean
@@ -276,26 +276,32 @@ public def monitorJobs
 /-- Exit code to return if `--no-build` is set and a build is required. -/
 public def noBuildCode : ExitCode := 3
 
-def Workspace.saveOutputs
-  [logger : MonadLog BaseIO] (ws : Workspace) (outputsRef? : Option CacheRef)
-  (out : IO.FS.Stream) (outputsFile : FilePath) (isVerbose : Bool)
+def BuildContext.saveOutputs
+  [logger : MonadLog BaseIO] (bctx : BuildContext) (out : IO.FS.Stream) (outputsFile : FilePath)
 : BaseIO Unit := do
-  unless ws.isRootArtifactCacheWritable do
-    logWarning s!"{ws.root.prettyName}: \
+  let some ref := bctx.outputsRef?
+    | print! out "Build missing input-to-output mappings. (This is likely a bug in Lake.)\n"
+      return
+  let ws := bctx.workspace
+  -- TODO: Carry proof index is in bounds in `BuildContext` when its workspace is non-opaque.
+  let some pkg := ws.packages[bctx.outputsIdx]?
+    | print! out "Tracked package not found. (This is likely a bug in Lake.)\n"
+      return
+  have : MonadWorkspace Id := ⟨ws⟩
+  unless Id.run pkg.isArtifactCacheWritable do
+    logWarning s!"{pkg.prettyName}: \
       the artifact cache is not enabled for this package, so the artifacts described \
       by the mappings produced by `-o` will not necessarily be available in the cache."
-  if let some ref := outputsRef? then
-    match (← (← ref.get).writeFile outputsFile ws.root.isPlatformIndependent ∅) with
-    | .ok _ log =>
-      if !log.isEmpty && isVerbose then
-        print! out "There were issues saving input-to-output mappings from the build:\n"
-        log.replay
-    | .error _ log =>
-      print! out "Failed to save input-to-output mappings from the build.\n"
-      if isVerbose then
-        log.replay
-  else
-    print! out "Workspace missing input-to-output mappings from build. (This is likely a bug in Lake.)\n"
+  let isVerbose := bctx.verbosity matches .verbose
+  match (← (← ref.get).writeFile outputsFile pkg.isPlatformIndependent ∅) with
+  | .ok _ log =>
+    if !log.isEmpty && isVerbose then
+      print! out "There were issues saving input-to-output mappings from the build:\n"
+      log.replay
+  | .error _ log =>
+    print! out "Failed to save input-to-output mappings from the build.\n"
+    if isVerbose then
+      log.replay
 
 def reportResult (cfg : BuildConfig) (out : IO.FS.Stream) (result : MonitorResult) : BaseIO Unit := do
   if result.failures.isEmpty then
@@ -351,7 +357,7 @@ def mkBuildContext
         return cfg.macosxDeploymentTarget?
     }
   outputsRef? := ← id do
-    if cfg.outputsFile?.isSome then
+    if cfg.outputsFile?.isSome && cfg.outputsIdx < ws.packages.size then
       some <$> CacheRef.mk
     else
       return none
@@ -386,12 +392,11 @@ def Workspace.startBuild
   compute.run.run'.run bctx |>.run nilTrace
 
 def finalizeBuild
-  (cfg : BuildConfig) (bctx : BuildContext ) (mctx : MonitorContext) (result : BuildResult α)
+  (cfg : BuildConfig) (bctx : BuildContext) (mctx : MonitorContext) (result : BuildResult α)
 : IO α := do
   reportResult cfg mctx.out result
   if let some outputsFile := cfg.outputsFile? then
-    bctx.workspace.saveOutputs (logger := mctx.logger)
-      bctx.outputsRef? mctx.out outputsFile (cfg.verbosity matches .verbose)
+    bctx.saveOutputs (logger := mctx.logger) mctx.out outputsFile
   match result.out with
   | .ok a =>
     return a

--- a/src/lake/Lake/CLI/Help.lean
+++ b/src/lake/Lake/CLI/Help.lean
@@ -701,11 +701,8 @@ instead of the Lake cache.
 Does not configure the workspace and thus does not execute arbitrary user
 code. However, because of this, the package's platform and toolchain settings
 will not be automatically detected for `--repo` and must be specified manually
-via `--platform` and `--toolchain` (if needed).
-
-Lake will still, by default, detect the target revision from the workspace
-directory's current Git revision. To upload outputs for a different revision,
-specify it with `--rev`."
+via `--platform` and `--toolchain` (if needed). Similarly, the source revision
+the outputs correspond to must be manually specified via `--rev`."
 
 def helpCacheClean :=
 "Removes ALL files from the local Lake cache

--- a/src/lake/Lake/CLI/Help.lean
+++ b/src/lake/Lake/CLI/Help.lean
@@ -118,7 +118,7 @@ def helpBuild :=
 "Build targets
 
 USAGE:
-  lake build [<targets>...] [-o <mappings>]
+  lake build [<targets>...] [-o <mappings>] [--package <name>]
 
 A target is specified with a string of the form:
 
@@ -163,11 +163,13 @@ TARGET EXAMPLES:        build the ...
 A bare `lake build` command will build the default target(s) of the root
 package. Package dependencies are not updated during a build.
 
-With the Lake cache enabled, the `-o` option will cause Lake to track the
-input-to-outputs mappings of targets in the root package touched during the
-build and write them to the specified file at the end of the build. These
-mappings can then be used to upload build artifacts to a remote cache with
-`lake cache put`."
+With the Lake cache enabled, Lake can track the targets the build covers
+(both those up-to-date and those newly built) and write the input-to-outputs
+mappings of each to a file specified by the `-o` option. By default, with `-o`,
+Lake will track the targets of the root package, use `--package` to select a
+different one. These mappings can then be used to upload the build artifacts
+to a remote cache with `lake cache put`. This will only include the artifacts
+from the covered targets. Other targets in the package will not be tracked."
 
 def helpQuery :=
 "Build targets and output results
@@ -592,6 +594,7 @@ USAGE:
   lake cache put <mappings>
 
 OPTIONS:
+  --package=<name>                upload for set package
   --service=<name>                upload to set cache service
   --scope=<remote-scope>          upload under set scope verbatim
   --repo=<github-repo>            scope w/ repository + toolchain & platform

--- a/src/lake/Lake/CLI/Main.lean
+++ b/src/lake/Lake/CLI/Main.lean
@@ -819,6 +819,8 @@ protected def putStaged : CliM PUnit := do
   processOptions lakeOption
   let opts ← getThe LakeOptions
   let stagingDir ← FilePath.mk <$> takeArg "staging directory"
+  let some rev := opts.rev?
+    | error "the `--rev` option must be set"
   let some scope := opts.scope?
     | error "the `--scope` or `--repo` option must be set"
   if opts.package?.isSome then
@@ -829,7 +831,6 @@ protected def putStaged : CliM PUnit := do
   let platform := opts.platform?.getD .none
   let toolchain := opts.toolchain?.getD .none
   let service ← computeUploadService opts.service? cfg.lakeEnv lakeCfg
-  let rev ← opts.rev?.getDM (computePackageRev cfg.wsDir)
   let outputsFile := stagingDir / stagingOutputsFile
   putCore rev outputsFile stagingDir service scope platform toolchain
 

--- a/src/lake/Lake/CLI/Main.lean
+++ b/src/lake/Lake/CLI/Main.lean
@@ -137,6 +137,7 @@ public def LakeOptions.mkLoadConfig (opts : LakeOptions) : EIO CliError LoadConf
 /-- Make a `BuildConfig` from a `LakeOptions`. -/
 def LakeOptions.mkBuildConfig
   (opts : LakeOptions) (out := OutStream.stderr) (showSuccess := false)
+  (outputsPackage? : Option Package := none)
 : BuildConfig where
   oldMode := opts.oldMode
   trustHash := opts.trustHash
@@ -146,7 +147,8 @@ def LakeOptions.mkBuildConfig
   failLv := opts.failLv
   outLv := opts.outLv
   ansiMode := opts.ansiMode
-  outputsFile? := opts.outputsFile?
+  outputsFile? := opts.outputsFile?.filter fun _ => outputsPackage?.isSome
+  outputsIdx := outputsPackage?.elim 0 (·.wsIdx)
   out; showSuccess
 
 export LakeOptions (mkLoadConfig mkBuildConfig)
@@ -687,23 +689,21 @@ protected def put : CliM PUnit := do
   let opts ← getThe LakeOptions
   let some scope := opts.scope?
     | error "the `--scope` or `--repo` option must be set"
-  if opts.package?.isSome then
-    error "the `--package` option is not supported for `cache put`"
   if opts.rev?.isSome then
     error "the `--rev` option is not supported for `cache put`; \
       to upload artifacts for different revisions, use the staging workflow, \
       e.g., `lake cache stage` and `lake cache put-staged`"
   noArgsRem do
   let cfg ← mkLoadConfig opts
-  let lakeEnv := cfg.lakeEnv
-  let pkg ← loadPackage cfg
-  let lakeCfg ← loadLakeConfig lakeEnv
-  let lakeCache := computeLakeCache pkg lakeEnv
+  let ws ← loadWorkspace cfg
+  let pkg ← match opts.package? with
+    | some pkg => parsePackageSpec ws pkg
+    | _ => pure ws.root
   let platform := cachePlatform pkg (opts.platform?.getD .system)
-  let toolchain := cacheToolchain pkg (opts.toolchain?.getD lakeEnv.cacheToolchain)
-  let service ← computeUploadService opts.service? lakeEnv lakeCfg
+  let toolchain := cacheToolchain pkg (opts.toolchain?.getD ws.lakeEnv.cacheToolchain)
+  let service ← computeUploadService opts.service? ws.lakeEnv ws.lakeConfig
   let rev ← computePackageRev pkg.dir
-  putCore rev file lakeCache.artifactDir service scope platform toolchain
+  putCore rev file ws.lakeCache.artifactDir service scope platform toolchain
 
 protected def add : CliM PUnit := do
   processOptions lakeOption
@@ -953,7 +953,13 @@ protected def build : CliM PUnit := do
   specs.forM fun spec =>
     unless spec.buildable do
       throw <| .invalidBuildTarget spec.info.key.toSimpleString
-  let buildConfig := mkBuildConfig opts (out := .stdout) (showSuccess := true)
+  let outputsPackage? ← id do
+    match opts.outputsFile?, opts.package? with
+    | some _, some pkg => some <$> parsePackageSpec ws pkg
+    | some _, none => return some ws.root
+    | none, some _ => error "`--package` requires `-o`"
+    | none, none => return none
+  let buildConfig := mkBuildConfig opts (out := .stdout) (showSuccess := true) outputsPackage?
   ws.runBuild (buildSpecs specs) buildConfig
 
 protected def checkBuild : CliM PUnit := do

--- a/tests/lake/tests/cache/clean.sh
+++ b/tests/lake/tests/cache/clean.sh
@@ -1,1 +1,1 @@
-rm -rf .lake lake-manifest.json produced.* Ignored.lean .git
+rm -rf .lake dep/.lake lake-manifest.json produced.* Ignored.lean .git

--- a/tests/lake/tests/cache/dep.toml
+++ b/tests/lake/tests/cache/dep.toml
@@ -1,0 +1,13 @@
+name = "test"
+enableArtifactCache = true
+platformIndependent = true
+
+[[lean_lib]]
+name = "Test"
+
+# A local dependency with neither the artifact cache nor platform
+# independence configured, so it follows the workspace default for the
+# former and is platform-dependent regardless of the root
+[[require]]
+name = "dep"
+path = "dep"

--- a/tests/lake/tests/cache/dep/Dep.lean
+++ b/tests/lake/tests/cache/dep/Dep.lean
@@ -1,0 +1,1 @@
+def dep := "dep"

--- a/tests/lake/tests/cache/dep/lakefile.toml
+++ b/tests/lake/tests/cache/dep/lakefile.toml
@@ -1,0 +1,4 @@
+name = "dep"
+
+[[lean_lib]]
+name = "Dep"

--- a/tests/lake/tests/cache/test.sh
+++ b/tests/lake/tests/cache/test.sh
@@ -208,6 +208,34 @@ test_lines 6 .lake/outputs.jsonl
 test_run -f platformIndependent.toml build Test:static -o .lake/outputs.jsonl
 test_lines 3 .lake/outputs.jsonl
 
+# Test producing output mappings for a dependency with `--package`
+test_run -f dep.toml update
+# Only the covered targets of the selected package are tracked,
+# even when targets of other packages are built as well
+test_run -f dep.toml build Test @dep/Dep -o .lake/outputs.jsonl --package=dep
+test_lines 2 .lake/outputs.jsonl
+test_run -f dep.toml build Test -o .lake/outputs.jsonl --package=dep
+test_lines 1 .lake/outputs.jsonl
+# Without `--package`, the root is tracked
+test_run -f dep.toml build Test @dep/Dep -o .lake/outputs.jsonl
+test_lines 3 .lake/outputs.jsonl
+# The platform independence of the selected package (not of the root)
+# decides whether platform-dependent outputs are included
+test_run -f dep.toml build @dep/Dep:static -o .lake/outputs.jsonl --package=dep
+test_lines 4 .lake/outputs.jsonl
+test_run -f dep.toml build Test:static -o .lake/outputs.jsonl
+test_lines 3 .lake/outputs.jsonl
+# A selected package without the artifact cache enabled is reported,
+# but its mappings are still produced
+LAKE_ARTIFACT_CACHE=false test_out \
+  'dep: the artifact cache is not enabled for this package' \
+  -f dep.toml build @dep/Dep -o .lake/outputs.jsonl --package=dep
+test_lines 2 .lake/outputs.jsonl
+test_err 'unknown package `bogus`' \
+  -f dep.toml build Test -o .lake/outputs.jsonl --package=bogus
+test_err '`--package` requires `-o`' -f dep.toml build Test --package=dep
+test_run update
+
 # Test `lake cache stage` and `lake cache unstage`
 test_run build Test:static -o .lake/outputs.jsonl
 test_lines 6 .lake/outputs.jsonl

--- a/tests/lake/tests/cacheTransfer/test.sh
+++ b/tests/lake/tests/cacheTransfer/test.sh
@@ -152,18 +152,20 @@ LAKE_CACHE_REVISION_ENDPOINT=bogus test_err 'these environment variables must be
   cache put bogus.jsonl --scope='bogus'
 
 # Verify `cache put-staged` rejects bad configurations
-with_endpoints test_err 'the `--scope` or `--repo` option must be set' \
-  cache put-staged bogus
+test_err 'the `--rev` option must be set' \
+  cache put-staged bogus --scope='bogus'
+test_err 'the `--scope` or `--repo` option must be set' \
+  cache put-staged bogus --rev='bogus'
 test_err 'the `--package` option does nothing for `cache put-staged`' \
-  cache put-staged bogus --scope='bogus' --package='bogus'
+  cache put-staged bogus --scope='bogus' --rev='bogus' --package='bogus'
 test_err 'the `--service` option must be set' \
-  cache put-staged bogus --scope='bogus'
+  cache put-staged bogus --scope='bogus' --rev='bogus'
 LAKE_CACHE_KEY= test_err 'the `--service` option must be set' \
-  cache put-staged bogus --scope='bogus'
+  cache put-staged bogus --scope='bogus' --rev='bogus'
 LAKE_CACHE_ARTIFACT_ENDPOINT=bogus test_err 'these environment variables must be set' \
-  cache put-staged bogus --scope='bogus'
+  cache put-staged bogus --scope='bogus' --rev='bogus'
 LAKE_CACHE_REVISION_ENDPOINT=bogus test_err 'these environment variables must be set' \
-  cache put-staged bogus --scope='bogus'
+  cache put-staged bogus --scope='bogus' --rev='bogus'
 
 # Verify `cache add` rejects bad configurations
 test_err '`--scope` and `--repo` require `--service`' \
@@ -446,21 +448,13 @@ test_out 'downloaded artifact' -v build Test --no-build
 match_text "GET /ok/api/v1/repositories/leanprover/test/artifacts/" "$SERVER_LOG"
 test_artifacts "$NUM_REPLAY_ARTS"
 
-# Verify staged artifacts can be uploaded and downloaded
+# Verify staged artifacts can be uploaded for a set revision and downloaded
 test_cmd rm -rf staging
 test_run cache stage outputs.jsonl staging
-test_run cache put-staged staging --scope=staged
-test_exp -f "$STORE_DIR/r0/staged/$REV.jsonl"
-test_cmd rm -rf .lake/build "$CACHE_DIR"
-test_run cache get --scope=staged --service=ok
-test_artifacts "$NUM_ARTS"
-test_run build Test --no-build
-
-# Verify staged outputs can be uploaded for another revision,
-# which `cache get --rev` then fetches instead of those of the head revision
 OLD_REV="$(git rev-parse HEAD~1)"
 test_run cache put-staged staging --scope=staged --rev="$OLD_REV"
 test_exp -f "$STORE_DIR/r0/staged/$OLD_REV.jsonl"
+test_exp ! -e "$STORE_DIR/r0/staged/$REV.jsonl"
 test_cmd rm -rf .lake/build "$CACHE_DIR"
 test_out "for revision $OLD_REV" cache get --scope=staged --service=ok --rev="$OLD_REV"
 test_artifacts "$NUM_ARTS"

--- a/tests/lake/tests/cacheTransfer/test.sh
+++ b/tests/lake/tests/cacheTransfer/test.sh
@@ -140,6 +140,8 @@ LAKE_CACHE_REVISION_ENDPOINT=bogus test_err 'both environment variables must be 
 with_endpoints test_err 'the `--scope` or `--repo` option must be set' cache put bogus.jsonl
 test_err 'the `--rev` option is not supported for `cache put`' \
   cache put bogus.jsonl --scope='bogus' --rev=bogus
+test_err 'unknown package `bogus`' \
+  cache put bogus.jsonl --scope='bogus' --package='bogus'
 test_err 'the `--service` option must be set' \
   cache put bogus.jsonl --scope='bogus'
 LAKE_CACHE_KEY= test_err 'the `--service` option must be set' \
@@ -366,12 +368,19 @@ match_text "POST /ok/api/v1/repositories/leanprover/test/artifacts" "$SERVER_LOG
 test_artifacts "$NUM_ARTS"
 test_run build Test --no-build
 
-# Verify `--package` fetches a single dependency through Reservoir,
-# using that dependency's scope and revision
+# Verify `-o` with `--package` tracks the outputs of the selected dependency
+# from the root workspace, matching those of a build of the dependency alone
 test_cmd rm -rf .lake/build "$CACHE_DIR"
 test_run -f dep.toml update
-test_run -d dep build Dep -o dep-outputs.jsonl
-test_run -d dep cache put dep-outputs.jsonl --repo=leanprover/dep
+test_run -f dep.toml build @dep/Dep -o dep-outputs.jsonl --package=dep
+test_run -d dep build Dep -o dep-only-outputs.jsonl
+test_cmd cmp -s dep-outputs.jsonl dep-only-outputs.jsonl
+
+# Verify `cache put` with `--package` uploads the outputs for the dependency
+# and `cache get` with `--package` fetches them back through Reservoir,
+# using that dependency's scope and revision
+test_run -f dep.toml cache put dep-outputs.jsonl --package=dep --repo=leanprover/dep
+test_exp -d "$STORE_DIR/r0/leanprover/dep"
 test_cmd rm -rf dep/.lake/build .lake/build "$CACHE_DIR"
 : > "$SERVER_LOG"
 # The other dependencies are left alone, so none is reported as skipped
@@ -393,7 +402,9 @@ test_run -f dep.toml build @dep/Dep --no-build
 
 # Verify `--package` also selects the dependency for a custom endpoint scope,
 # where `--rev` resolves within that dependency's repository
-test_run -d dep cache put dep-outputs.jsonl --scope=dep
+test_run -f dep.toml cache put dep-outputs.jsonl --package=dep --scope=dep
+test_exp -f "$STORE_DIR/r0/dep/$REV.jsonl"
+test_cmd cmp -s dep-outputs.jsonl "$STORE_DIR/r0/dep/$REV.jsonl"
 test_cmd rm -rf dep/.lake/build .lake/build "$CACHE_DIR"
 test_run -f dep.toml cache get --package=dep --scope=dep --service=ok --rev=HEAD
 test_exp -d "$CACHE_DIR/revisions/dep"

--- a/tests/lake/tests/cacheTransfer/test.sh
+++ b/tests/lake/tests/cacheTransfer/test.sh
@@ -138,8 +138,6 @@ LAKE_CACHE_REVISION_ENDPOINT=bogus test_err 'both environment variables must be 
 
 # Verify `cache put` rejects bad configurations
 with_endpoints test_err 'the `--scope` or `--repo` option must be set' cache put bogus.jsonl
-test_err 'the `--package` option is not supported for `cache put`' \
-  cache put bogus.jsonl --scope='bogus' --package='bogus'
 test_err 'the `--rev` option is not supported for `cache put`' \
   cache put bogus.jsonl --scope='bogus' --rev=bogus
 test_err 'the `--service` option must be set' \


### PR DESCRIPTION
This PR adds a `--package` option to `lake build` and `lake cache put`. On `lake build`, `-o` with `--package` will track the specified package's build outputs instead of the root's. The outputs can then be uploaded via `lake cache put --package`.  Also, to minimize incorrect uploads, `lake cache put-staged`  now requires `--rev` to be manually set. 

**Minor Changes**

* `-o` now only works for `lake build` and is silently ignored on other commands (e.g., `lake query`. `lake exe`).
* `lake cache put` now loads the whole workspace.

**Breaking change:** Existing `lake cache put-staged` usages without `--rev` will need to specific their head revision (e.g., via  `--rev=$(git rev-parse HEAD)`). Previously, there was already a risk of uploading staged outputs for the wrong revision (e.g., if it was run in a different working directory). However, the ability of the outputs to come from a different package has worsen this. Manual specification mitigates this risk and makes sense for the security-conscious nature of the staging commands.
